### PR TITLE
#35 Specify Account Store During Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ composer.phar
 *.tgz
 *.zip
 tests/code-coverage
+.envrc

--- a/README.md
+++ b/README.md
@@ -797,7 +797,8 @@ At the time you create the request, it is likely that you may know the account s
 
 ```php
 $accountStore = $anAccountStoreMapping->getAccountStore();
-$authenticationRequest = new UsernamePasswordRequest('usernameOrEmail', 'password', $accountStore);
+$authenticationRequest = new UsernamePasswordRequest('usernameOrEmail', 'password', 
+    array('accountStore' => $accountStore));
 $result = $application->authenticateAccount($authenticationRequest);
 ```
 

--- a/README.md
+++ b/README.md
@@ -787,6 +787,20 @@ try {
 }
 ```
 
+#### Log In (Authenticate) an Account with Specific AccountStore
+
+When you submit an authentication request to Stormpath, instead of executing the default login logic that cycles through account stores to find an account match, you can specify the `AccountStore` where the login attempt will be issued to.
+
+At the time you create the request, it is likely that you may know the account store where the account resides, therefore you can target it directly. This will speed up the authentication attempt (especially if you have a very large number of account stores).
+
+##### Example Request
+
+```php
+$accountStore = $anAccountStoreMapping->getAccountStore();
+$authenticationRequest = new UsernamePasswordRequest('usernameOrEmail', 'password', $accountStore);
+$result = $application->authenticateAccount($authenticationRequest);
+```
+
 ### Password Reset
 
 A password reset workflow, if configured on the directory the account is

--- a/src/Stormpath/Authc/AuthenticationRequest.php
+++ b/src/Stormpath/Authc/AuthenticationRequest.php
@@ -26,4 +26,6 @@ interface AuthenticationRequest {
     function getHost();
 
     function clear();
+
+    function getAccountStore();
 }

--- a/src/Stormpath/Authc/BasicAuthenticator.php
+++ b/src/Stormpath/Authc/BasicAuthenticator.php
@@ -56,6 +56,10 @@ class BasicAuthenticator
         $attempt = $this->dataStore->instantiate(Stormpath::BASIC_LOGIN_ATTEMPT);
         $attempt->setValue($value);
 
+        if ($request->getAccountStore() != null) {
+            $attempt->setAccountStore($request->getAccountStore());
+        }
+
         $href = $parentHref . '/loginAttempts';
 
         return $this->dataStore->create($href, $attempt, Stormpath::AUTHENTICATION_RESULT, $options);

--- a/src/Stormpath/Authc/UsernamePasswordRequest.php
+++ b/src/Stormpath/Authc/UsernamePasswordRequest.php
@@ -17,6 +17,9 @@ namespace Stormpath\Authc;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use Stormpath\Resource\Account;
+use Stormpath\Resource\AccountStore;
+
 class UsernamePasswordRequest implements AuthenticationRequest
 {
     private $username;
@@ -30,7 +33,19 @@ class UsernamePasswordRequest implements AuthenticationRequest
         $this->username = $username;
 
         $this->host = isset($options['host']) ? $options['host'] : null;
-        $this->accountStore = isset($options['accountStore']) ? $options['accountStore'] : null;
+
+        if (isset($options['accountStore']))
+        {
+            $accountStore = $options['accountStore'];
+            if ($accountStore instanceof AccountStore)
+            {
+                $this->accountStore = $accountStore;
+            }
+            else
+            {
+                throw new \InvalidArgumentException("The value for accountStore in the \$options array should be an instance of \\Stormpath\\Resource\\AccountStore");
+            }
+        }
     }
 
     public function getPrincipals()

--- a/src/Stormpath/Authc/UsernamePasswordRequest.php
+++ b/src/Stormpath/Authc/UsernamePasswordRequest.php
@@ -22,12 +22,15 @@ class UsernamePasswordRequest implements AuthenticationRequest
     private $username;
     private $password;
     private $host;
+    private $accountStore;
 
-    public function __construct($username, $password, $host = null)
+    public function __construct($username, $password, array $options = array())
     {
-        $this->host = $host;
         $this->password = $password ? str_split($password) : array();
         $this->username = $username;
+
+        $this->host = isset($options['host']) ? $options['host'] : null;
+        $this->accountStore = isset($options['accountStore']) ? $options['accountStore'] : null;
     }
 
     public function getPrincipals()
@@ -40,6 +43,11 @@ class UsernamePasswordRequest implements AuthenticationRequest
         return $this->password;
     }
 
+    public function getAccountStore()
+    {
+        return $this->accountStore;
+    }
+
     // @codeCoverageIgnoreStart
     public function getHost()
     {
@@ -47,7 +55,7 @@ class UsernamePasswordRequest implements AuthenticationRequest
     }
 
     /**
-     * Clears out (nulls) the username, password, and host.  The password bytes are explicitly set to
+     * Clears out (nulls) the username, password, and options.  The password bytes are explicitly set to
      * <tt>0x00</tt> to eliminate the possibility of memory access at a later time.
      */
     public function clear()

--- a/src/Stormpath/DataStore/DefaultDataStore.php
+++ b/src/Stormpath/DataStore/DefaultDataStore.php
@@ -291,6 +291,11 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
                 $property = $this->toSimpleReference($name, $property);
             }
 
+            else if ($property instanceof \Stormpath\Resource\Resource)
+            {
+                $property = $this->toStdClass($property);
+            }
+
 
 
             $properties->$name = $property;

--- a/src/Stormpath/Resource/BasicLoginAttempt.php
+++ b/src/Stormpath/Resource/BasicLoginAttempt.php
@@ -24,6 +24,7 @@ class BasicLoginAttempt extends Resource
 {
     const TYPE = "type";
     const VALUE = "value";
+    const ACCOUNT_STORE = "accountStore";
 
     public function __construct(InternalDataStore $dataStore = null, \stdClass $properties = null) {
         parent::__construct($dataStore, $properties);
@@ -45,5 +46,15 @@ class BasicLoginAttempt extends Resource
     public function setValue($value)
     {
         $this->setProperty(self::VALUE, $value);
+    }
+
+    public function getAccountStore()
+    {
+        $this->getProperty(self::ACCOUNT_STORE);
+    }
+
+    public function setAccountStore($accountStore)
+    {
+        $this->setProperty(self::ACCOUNT_STORE, $accountStore);
     }
 }

--- a/tests/Stormpath/Tests/Resource/ApplicationTest.php
+++ b/tests/Stormpath/Tests/Resource/ApplicationTest.php
@@ -279,6 +279,24 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
             $this->assertContains('7104', $re->getMoreInfo());
         }
 
+        try
+        {
+            new \Stormpath\Authc\UsernamePasswordRequest(
+                'super_dupper_unique_email@unknown123.kot',
+                'superP4ss',
+                array('accountStore' => 'not an instance of AccountStore'));
+
+            $this->fail('UsernamePasswordRequest instantiation should have failed.');
+        }
+        catch (\InvalidArgumentException $iae)
+        {
+            $this->assertEquals("The value for accountStore in the \$options array should be an instance of \\Stormpath\\Resource\\AccountStore", $iae->getMessage());
+        }
+        catch (\Exception $e)
+        {
+            $this->fail('UsernamePasswordRequest instantiation with wrong type for account store should have thrown InvalidArgumentException.');
+        }
+
         $account->delete();
         $accountStoreMappingB->delete();
         $accountStoreMappingA->delete();


### PR DESCRIPTION
The constructor for `UsernamePasswordRequest` is overloaded in the Java client. Since PHP doesn't support constructor overloading, I could use the following strategy to simulate the behavior: http://php.net/manual/en/language.oop5.decon.php#99903
