### PR TITLE
#39 - Add custom data when creating an account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ composer.phar
 *.tgz
 *.zip
 tests/code-coverage
+.envrc
+

--- a/tests/Stormpath/Tests/BaseTest.php
+++ b/tests/Stormpath/Tests/BaseTest.php
@@ -75,6 +75,26 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         \Stormpath\Client::$cacheManager = 'Array';
     }
 
+    /**
+     * This function instantiates a new client but doesn't modify
+     * the BaseTest::$client variable.
+     */
+    protected function newClientInstance()
+    {
+        $builder = new \Stormpath\ClientBuilder();
+
+        $newClient = $builder->setApiKeyFileLocation(\Stormpath\Client::$apiKeyFileLocation)->
+            setApiKeyProperties(\Stormpath\Client::$apiKeyProperties)->
+            setApiKeyIdPropertyName(\Stormpath\Client::$apiKeyIdPropertyName)->
+            setApiKeySecretPropertyName(\Stormpath\Client::$apiKeySecretPropertyName)->
+            setCacheManager(\Stormpath\Client::$cacheManager)->
+            setCacheManagerOptions(\Stormpath\Client::$cacheManagerOptions)->
+            setBaseURL(\Stormpath\Client::$baseUrl)->
+            build();
+
+        return $newClient;
+    }
+
     public function testClient()
     {
         self::$client = \Stormpath\Client::getInstance();

--- a/tests/Stormpath/Tests/Resource/ApplicationTest.php
+++ b/tests/Stormpath/Tests/Resource/ApplicationTest.php
@@ -132,6 +132,27 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
         $account->delete();
     }
 
+    public function testCreateAccountWithCustomData()
+    {
+        $application = self::$application;
+
+        $account = \Stormpath\Resource\Account::instantiate(array('givenName' => 'Account Name',
+            'surname' => 'Surname',
+            'username' => md5(time()) . 'username',
+            'email' => md5(time()) .'@unknown123.kot',
+            'password' => 'superP4ss'));
+
+        $customData = $account->customData;
+        $customData->phone = "12345";
+
+        $application->createAccount($account);
+
+        $account = \Stormpath\Resource\Account::get($account->href);
+        $this->assertEquals("12345", $account->customData->phone);
+
+        $account->delete();
+    }
+
     public function testCreateGroup()
     {
         $application = self::$application;

--- a/tests/Stormpath/Tests/Resource/ApplicationTest.php
+++ b/tests/Stormpath/Tests/Resource/ApplicationTest.php
@@ -21,6 +21,7 @@ namespace Stormpath\Tests\Resource;
 use JWT;
 use Stormpath\Client;
 use Stormpath\Resource\Application;
+use Stormpath\Stormpath;
 use Stormpath\Util\UUID;
 
 class ApplicationTest extends \Stormpath\Tests\BaseTest {
@@ -251,8 +252,6 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
     public function testCreateAccountWithCustomData()
     {
-        $application = self::$application;
-
         $account = \Stormpath\Resource\Account::instantiate(array('givenName' => 'Account Name',
             'surname' => 'Surname',
             'username' => md5(time()) . 'username',
@@ -262,7 +261,8 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
         $customData = $account->customData;
         $customData->phone = "12345";
 
-        $application->createAccount($account);
+        $newClient = self::newClientInstance();
+        $account = $newClient->getDataStore()->create(\Stormpath\Resource\Account::PATH, $account, Stormpath::ACCOUNT);
 
         $account = \Stormpath\Resource\Account::get($account->href);
         $this->assertEquals("12345", $account->customData->phone);

--- a/tests/Stormpath/Tests/Resource/ApplicationTest.php
+++ b/tests/Stormpath/Tests/Resource/ApplicationTest.php
@@ -252,6 +252,8 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
     public function testCreateAccountWithCustomData()
     {
+        $application = self::$application;
+
         $account = \Stormpath\Resource\Account::instantiate(array('givenName' => 'Account Name',
             'surname' => 'Surname',
             'username' => md5(time()) . 'username',
@@ -261,10 +263,10 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
         $customData = $account->customData;
         $customData->phone = "12345";
 
-        $newClient = self::newClientInstance();
-        $account = $newClient->getDataStore()->create(\Stormpath\Resource\Account::PATH, $account, Stormpath::ACCOUNT);
+        $account = $application->createAccount($account);
 
-        $account = \Stormpath\Resource\Account::get($account->href);
+        $newClient = self::newClientInstance();        
+        $account = $newClient->get($account->href, Stormpath::ACCOUNT);
         $this->assertEquals("12345", $account->customData->phone);
 
         $account->delete();


### PR DESCRIPTION
Not sure if I should try to disable the cache for this particular test (I guess it can be done by creating a new client using the `'Null'` cache manager).