### PR TITLE
(#47) Custom Data not updating when calling save() on resource

### DIFF
--- a/src/Stormpath/DataStore/DefaultDataStore.php
+++ b/src/Stormpath/DataStore/DefaultDataStore.php
@@ -292,12 +292,14 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
 
             $property = $resource->getProperty($name);
 
+            $nameIsCustomData = $name == Resource::CUSTOMDATA_PROP_NAME;
+
             if ($property instanceof \Stormpath\Resource\CustomData)
             {
                 $property = $this->toStdClass($property, true);
             }
 
-            else if ($property instanceof \stdClass && $customData === false)
+            else if ($property instanceof \stdClass && $customData === false && !$nameIsCustomData)
             {
                 $property = $this->toSimpleReference($name, $property);
             }

--- a/src/Stormpath/DataStore/DefaultDataStore.php
+++ b/src/Stormpath/DataStore/DefaultDataStore.php
@@ -20,10 +20,10 @@ namespace Stormpath\DataStore;
 
 use Stormpath\ApiKey;
 use Stormpath\Cache\Cacheable;
-use Stormpath\Cache\CacheManager;
 use Stormpath\Http\DefaultRequest;
 use Stormpath\Http\Request;
 use Stormpath\Http\RequestExecutor;
+use Stormpath\Resource\CustomData;
 use Stormpath\Resource\Error;
 use Stormpath\Resource\Resource;
 use Stormpath\Resource\ResourceError;
@@ -292,7 +292,7 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
 
             $property = $resource->getProperty($name);
 
-            $nameIsCustomData = $name == Resource::CUSTOMDATA_PROP_NAME;
+            $nameIsCustomData = $name == CustomData::CUSTOMDATA_PROP_NAME;
 
             if ($property instanceof \Stormpath\Resource\CustomData)
             {

--- a/src/Stormpath/Resource/CustomData.php
+++ b/src/Stormpath/Resource/CustomData.php
@@ -3,6 +3,8 @@
 
 class CustomData extends InstanceResource implements Saveable {
 
+    const CUSTOMDATA_PROP_NAME = "customData";
+
     public function __get($key)
     {
        return $this->getProperty($key);

--- a/src/Stormpath/Resource/Resource.php
+++ b/src/Stormpath/Resource/Resource.php
@@ -32,6 +32,7 @@ class Resource extends Magic
     private $options;
 
     const HREF_PROP_NAME = "href";
+    const CUSTOMDATA_PROP_NAME = "customData";
 
     public function __construct(InternalDataStore $dataStore = null, \stdClass $properties = null, array $options = array())
     {

--- a/src/Stormpath/Resource/Resource.php
+++ b/src/Stormpath/Resource/Resource.php
@@ -32,7 +32,6 @@ class Resource extends Magic
     private $options;
 
     const HREF_PROP_NAME = "href";
-    const CUSTOMDATA_PROP_NAME = "customData";
 
     public function __construct(InternalDataStore $dataStore = null, \stdClass $properties = null, array $options = array())
     {

--- a/tests/Stormpath/Tests/Resource/ApplicationTest.php
+++ b/tests/Stormpath/Tests/Resource/ApplicationTest.php
@@ -265,8 +265,8 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
         $account = $application->createAccount($account);
 
-        $newClient = self::newClientInstance();        
-        $account = $newClient->get($account->href, Stormpath::ACCOUNT);
+        $newClient = self::newClientInstance();
+        $account = $newClient->dataStore->getResource($account->href, Stormpath::ACCOUNT);
         $this->assertEquals("12345", $account->customData->phone);
 
         $account->delete();
@@ -560,7 +560,8 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
         $cd->remove('unitTest');
 
-        $application = \Stormpath\Resource\Application::get(self::$application->href);
+        $newClient = self::newClientInstance();
+        $application = $newClient->dataStore->getResource(self::$application->href, Stormpath::APPLICATION);
         $customData = $application->customData;
         $this->assertNull($customData->unitTest);
     }
@@ -576,7 +577,8 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
         $cd->delete();
 
-        $application = \Stormpath\Resource\Application::get(self::$application->href);
+        $newClient = self::newClientInstance();
+        $application = $newClient->dataStore->getResource(self::$application->href, Stormpath::APPLICATION);
         $customData = $application->customData;
         $this->assertNull($customData->unitTest);
         $this->assertNull($customData->rank);

--- a/tests/Stormpath/Tests/Resource/DirectoryTest.php
+++ b/tests/Stormpath/Tests/Resource/DirectoryTest.php
@@ -18,6 +18,8 @@
 namespace Stormpath\Tests\Resource;
 
 
+use Stormpath\Stormpath;
+
 class DirectoryTest extends \Stormpath\Tests\BaseTest {
 
     private static $directory;
@@ -151,6 +153,24 @@ class DirectoryTest extends \Stormpath\Tests\BaseTest {
         $customData = $directory->customData;
         $this->assertEquals('some change', $customData->unitTest);
 
+        // testing for issue #47
+        $directory = \Stormpath\Resource\Directory::instantiate(array(
+            'name' => 'Test Directory'.md5(time()),
+            'description' => 'Test Directory description'));
+        self::createResource(\Stormpath\Resource\Directory::PATH, $directory);
+
+        $directory->description = 'Test description';
+        $customData = $directory->customData;
+        $customData->companyName = 'Company Test';
+        $directory->save();
+
+        $newClient = self::newClientInstance();
+        $directory = $newClient->dataStore->getResource($directory->href, Stormpath::DIRECTORY);
+        $this->assertEquals('Test description', $directory->description);
+        $this->assertEquals('Company Test', $directory->customData->companyName);
+
+        $directory->delete();
+
     }
 
     public function testRemovingCustomData()
@@ -159,7 +179,8 @@ class DirectoryTest extends \Stormpath\Tests\BaseTest {
 
         $cd->remove('unitTest');
 
-        $directory = \Stormpath\Resource\Directory::get(self::$directory->href);
+        $newClient = self::newClientInstance();
+        $directory = $newClient->dataStore->getResource(self::$directory->href, Stormpath::DIRECTORY);
         $customData = $directory->customData;
         $this->assertNull($customData->unitTest);
     }
@@ -175,7 +196,8 @@ class DirectoryTest extends \Stormpath\Tests\BaseTest {
 
         $cd->delete();
 
-        $directory = \Stormpath\Resource\Directory::get(self::$directory->href);
+        $newClient = self::newClientInstance();
+        $directory = $newClient->dataStore->getResource(self::$directory->href, Stormpath::DIRECTORY);
         $customData = $directory->customData;
         $this->assertNull($customData->unitTest);
         $this->assertNull($customData->rank);

--- a/tests/Stormpath/Tests/Resource/GroupTest.php
+++ b/tests/Stormpath/Tests/Resource/GroupTest.php
@@ -18,6 +18,8 @@
 namespace Stormpath\Tests\Resource;
 
 
+use Stormpath\Stormpath;
+
 class GroupTest extends \Stormpath\Tests\BaseTest {
 
     private static $directory;
@@ -149,7 +151,8 @@ class GroupTest extends \Stormpath\Tests\BaseTest {
 
         $cd->remove('unitTest');
 
-        $group = \Stormpath\Resource\Group::get(self::$group->href);
+        $newClient = self::newClientInstance();
+        $group = $newClient->dataStore->getResource(self::$group->href, Stormpath::GROUP);
         $customData = $group->customData;
         $this->assertNull($customData->unitTest);
     }
@@ -165,7 +168,8 @@ class GroupTest extends \Stormpath\Tests\BaseTest {
 
         $cd->delete();
 
-        $group = \Stormpath\Resource\Group::get(self::$group->href);
+        $newClient = self::newClientInstance();
+        $group = $newClient->dataStore->getResource(self::$group->href, Stormpath::GROUP);
         $customData = $group->customData;
         $this->assertNull($customData->unitTest);
         $this->assertNull($customData->rank);


### PR DESCRIPTION
This is the bugfix proposed. The problem is in the `DefaultDataStore->toStdClass()` method. When calling `save()` from the parent `Resource`, `customData` is going to be read as a `\stdClass` (rather than a `CustomData`), so given the conditions in the `toStdClass()` method, the `customData` object is always getting converted to a simple reference (the one that only contains an `href`), so changed data was never making it to the BE. I changed the conditions so `customData` doesn't suffer any changes when it's already in `\stdClass` form.

Also when making this change, the tests for removing custom data properties started failing. It turns out these tests were reading cached versions of the `Resource`s containing the affected custom data to validate the properties were deleted, and with the previous bug this cached custom data always was a simple reference, so they passed because the removed properties weren't present. 

With the bugfix the cached versions now could contain other properties besides `href`, so tests failed (the `remove()` method also deletes the property from the cache but only in the `CustomData` object, it doesn't delete it on the parent `Resource` that contains it). I changed the tests to bypass the cache by using a new instance of the `Client`.
