### PR TITLE
Fix for Issue #48.  

### DIFF
--- a/src/Stormpath/DataStore/DefaultDataStore.php
+++ b/src/Stormpath/DataStore/DefaultDataStore.php
@@ -117,7 +117,9 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
             $data = $this->executeRequest(Request::METHOD_GET, $href, '', $queryString);
         }
 
-        if($this->resourceIsCacheable($data)) {
+        //Check to see if the resource can be cached
+        //Only if the query string does not exist
+        if($this->resourceIsCacheable($data) && empty($queryString)) {
             $this->addDataToCache($data, $queryString);
         }
 

--- a/tests/Stormpath/Tests/Cache/CacheTest.php
+++ b/tests/Stormpath/Tests/Cache/CacheTest.php
@@ -102,6 +102,43 @@ class CacheTest extends BaseTest
         $application->delete();
     }
 
+    public function testDoesNotCacheExpandedResource()
+    {
+        $cache = parent::$client->dataStore->cache;
+        // Create Account and add to Group
+        $directory = \Stormpath\Resource\Directory::instantiate(array('name' => 'Main Directory' .md5(time())));
+        self::createResource(\Stormpath\Resource\Directory::PATH, $directory);
+
+        $group = \Stormpath\Resource\Group::instantiate(array('name' => 'A New Group' . md5(time())));
+
+        $directory->createGroup($group);
+
+        $account = \Stormpath\Resource\Account::instantiate(array('givenName' => 'Account Name',
+            'surname' => 'Surname',
+            'email' => md5(time()) .'@unknown12345.kot',
+            'password' => 'superP4ss'));
+
+        $directory->createAccount($account);
+
+        $groupMembership = \Stormpath\Resource\GroupMembership::instantiate();
+        $groupMembership->account = $account;
+        $groupMembership->group = $group;
+        $groupMembership = \Stormpath\Resource\GroupMembership::create($groupMembership);
+        // Check the cache
+        $acct = \Stormpath\Resource\Account::get($account->href,array('expand'=>'groups,groupMemberships'));
+        $this->assertEquals($acct->surname, 'Surname', 'one');
+
+        // Make change to the account
+        $account->surname = "Test";
+        $account->save();
+        $acct2 = \Stormpath\Resource\Account::get($account->href,array('expand'=>'groups,groupMemberships'));
+
+        $this->assertNull($cache->get($acct->href.":groups,groupMemberships"));
+        $this->assertNull($cache->get($acct2->href.":groups,groupMemberships"));
+
+        $directory->delete();
+    }
+
     public function testNullCacheDoesNotCache()
     {
         $origClient = parent::$client->dataStore->cache;


### PR DESCRIPTION
As per the comment "The fix should really be to only cache the resources by Href, excluding any query string. A reason for this is that we currently don't cache collection resources so retrieving a resource with a query string for search or expansion of collection resources will very likely return an inaccurate result."  When there is an expanded resource or a query string, the cacheing of this is skipped