### PR TITLE
Injectable Http Client

### DIFF
--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,6 +19,7 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
+use Stormpath\Http\RequestExecutor;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
@@ -100,13 +101,13 @@ class Client extends Magic
      * @param $baseUrl optional parameter for specifying the base URL when not using the default one
      *         (https://api.stormpath.com/v1).
      */
-    public function __construct(ApiKey $apiKey, $cacheManager, $cacheManagerOptions, $baseUrl = null)
+    public function __construct(ApiKey $apiKey, $cacheManager, $cacheManagerOptions, $baseUrl = null, RequestExecutor $requestExecutor = null)
     {
         parent::__construct();
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $requestExecutor = new HttpClientRequestExecutor();
+        $requestExecutor = ($requestExecutor === null ? new HttpClientRequestExecutor() : $requestExecutor);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);
     }

--- a/src/Stormpath/Http/HttpClientRequestExecutor.php
+++ b/src/Stormpath/Http/HttpClientRequestExecutor.php
@@ -29,9 +29,9 @@ class HttpClientRequestExecutor implements RequestExecutor
     private $httpClient;
     private $signer;
 
-    public function __construct()
+    public function __construct(Client $client = null)
     {
-        $this->httpClient = new Client();
+        $this->httpClient = ($client === null ? new Client() : $client);
         $this->signer = new Sauthc1Signer;
     }
 


### PR DESCRIPTION
In order to allow for logging and profiling of HTTP requests, we'd like to be able to inject a custom instance of the Guzzle client used in the Request Executor. In order to make this possible, I've made both the request executor and the Guzzle client injectable into the Stormpath Client and the HttpClientRequestExecutor respectively.

Both of them are injectable as *optional* constructor arguments, making this an entirely backwards compatible change.