### PR TITLE
Allow setting Authentication Request Signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,36 @@ Array caching system.
     
 Then you would call it the same way you do for a cache manager normally.  
 
+### Authentication Scheme Configuration
+You can choose one of two authentication schemes to authenticate with Stormpath:
+
+- Stormpath SAuthc1 Authentication: This is the recommended approach, and the default setting. This approach computes 
+a cryptographic digest of the request and sends the digest value along with the request. If the transmitted digest 
+matches what the Stormpath API server computes for the same request, the request is authenticated. The Stormpath 
+SAuthc1 digest-based authentication scheme is more secure than standard HTTP digest authentication.
+
+- Basic Authentication: This is only recommended when your application runs in an environment outside of your 
+control, and that environment manipulates your application’s request headers when requests are made. Google App 
+Engine is one known such environment. However, Basic Authentication is not as secure as Stormpath’s SAuthc 
+algorithm, so only use this if you are forced to do so by your application runtime environement.
+
+When no authentication scheme is explicitly configured, Sauthc1 is used by default.
+
+If you must change to basic authentication for these special environments, set the authenticationScheme property using
+`STORMPATH::AUTHENTICATION_SCHEME_BASIC` or `STORMPATH::AUTHENTICATION_SCHEME_SAUTHC1`:
+
+  ```php
+    \Stormpath\Client::$authenticationScheme = 'STORMPATH::AUTHENTICATION_SCHEME_BASIC';
+  ```
+  OR
+  
+  ```php
+     $builder = new \Stormpath\ClientBuilder();
+     $client = $builder->setAuthenticationScheme(STORMPATH::AUTHENTICATION_SCHEME_BASIC)
+                    ->build();
+  ```
+
+
 ### Accessing Resources
 
 Most of the work you do with Stormpath is done through the applications

--- a/README.md
+++ b/README.md
@@ -398,16 +398,16 @@ algorithm, so only use this if you are forced to do so by your application runti
 When no authentication scheme is explicitly configured, Sauthc1 is used by default.
 
 If you must change to basic authentication for these special environments, set the authenticationScheme property using
-`STORMPATH::AUTHENTICATION_SCHEME_BASIC` or `STORMPATH::AUTHENTICATION_SCHEME_SAUTHC1`:
+`Stormpath::AUTHENTICATION_SCHEME_BASIC` or `Stormpath::AUTHENTICATION_SCHEME_SAUTHC1`:
 
   ```php
-    \Stormpath\Client::$authenticationScheme = 'STORMPATH::AUTHENTICATION_SCHEME_BASIC';
+    \Stormpath\Client::$authenticationScheme = 'Stormpath::AUTHENTICATION_SCHEME_BASIC';
   ```
   OR
   
   ```php
      $builder = new \Stormpath\ClientBuilder();
-     $client = $builder->setAuthenticationScheme(STORMPATH::AUTHENTICATION_SCHEME_BASIC)
+     $client = $builder->setAuthenticationScheme(Stormpath::AUTHENTICATION_SCHEME_BASIC)
                     ->build();
   ```
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "autoload": {
-        "psr-4": {
+        "psr-0": {
             "Stormpath\\": "src/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "autoload": {
-        "psr-0": {
+        "psr-4": {
             "Stormpath\\": "src/"
         }
     },

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -21,6 +21,7 @@ namespace Stormpath;
 use Stormpath\DataStore\DefaultDataStore;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
+use Stormpath\Stormpath;
 use Stormpath\Util\Magic;
 
 function toObject($properties)
@@ -81,7 +82,7 @@ class Client extends Magic
 
     public static $cacheManager = 'Array';
 
-    public static $authenticationScheme = \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+    public static $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
 
     public static $cacheManagerOptions = array();
 
@@ -202,7 +203,7 @@ class Client extends Magic
         $signer = "\\Stormpath\\Http\\Authc\\" . self::$authenticationScheme . "Signer";
 
         if(!class_exists($signer))
-            $signer = "\\Stormpath\\Http\\Authc\\" . \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
+            $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
 
         return $signer;
     }

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -109,7 +109,8 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $signer = "\\Stormpath\\Http\\Authc\\" . self::$authenticationScheme . "Signer";
+        $signer = $this->resolveSigner();
+
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
@@ -196,6 +197,16 @@ class Client extends Magic
     public static function tearDown()
     {
         static::$instance = NULL;
+    }
+
+    private function resolveSigner()
+    {
+        $signer = "\\Stormpath\\Http\\Authc\\" . self::$authenticationScheme . "Signer";
+
+        if(!class_exists($signer))
+            $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
+
+        return $signer;
     }
 
 

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -108,8 +108,8 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $signer = $this->resolveSigner();
-
+//        $signer = $this->resolveSigner();
+        $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -111,7 +111,7 @@ class Client extends Magic
 //        $signer = $this->resolveSigner();
         $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
 
-        $requestExecutor = new HttpClientRequestExecutor(new $signer());
+        $requestExecutor = new HttpClientRequestExecutor(new \Stormpath\Http\Authc\SAuthc1Signer());
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,6 +19,7 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
+use Stormpath\Http\Authc\SAuthc1Signer;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
@@ -111,7 +112,7 @@ class Client extends Magic
 //        $signer = $this->resolveSigner();
         $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
 
-        $requestExecutor = new HttpClientRequestExecutor(new \Stormpath\Http\Authc\SAuthc1Signer());
+        $requestExecutor = new HttpClientRequestExecutor(new SAuthc1Signer());
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -109,7 +109,7 @@ class Client extends Magic
         self::$cacheManagerOptions = $cacheManagerOptions;
 
 //        $signer = $this->resolveSigner();
-        $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
+        $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -82,6 +82,8 @@ class Client extends Magic
 
     public static $cacheManager = 'Array';
 
+    public static $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+
     public static $cacheManagerOptions = array();
 
     private static $instance;
@@ -161,6 +163,7 @@ class Client extends Magic
                               setCacheManager(self::$cacheManager)->
                               setCacheManagerOptions(self::$cacheManagerOptions)->
                               setBaseURL(self::$baseUrl)->
+                              setAuthenticationScheme(self::$authenticationScheme)->
                               build();
         }
 

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -22,7 +22,6 @@ use Stormpath\DataStore\DefaultDataStore;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
-use Stormpath\Stormpath;
 use Stormpath\Util\Magic;
 
 function toObject($properties)

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,6 +19,7 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
+use Stormpath\Http\Authc\Sauthc1Signer;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
@@ -108,7 +109,9 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $requestExecutor = new HttpClientRequestExecutor();
+        $signer = "\\Stormpath\\Http\\Authc\\" . self::$authenticationScheme . "Signer";
+        $requestExecutor = new HttpClientRequestExecutor(new $signer);
+
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);
     }

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -109,7 +109,7 @@ class Client extends Magic
         self::$cacheManagerOptions = $cacheManagerOptions;
 
 //        $signer = $this->resolveSigner();
-        $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
+        $signer = "Stormpath\\Http\\Authc\\SAuthc1Signer";
 
         $requestExecutor = new HttpClientRequestExecutor(new $signer());
 

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,10 +19,8 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
-use Stormpath\Http\Authc\Sauthc1Signer;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
-use Stormpath\Stormpath;
 use Stormpath\Util\Magic;
 
 function toObject($properties)
@@ -83,7 +81,7 @@ class Client extends Magic
 
     public static $cacheManager = 'Array';
 
-    public static $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+    public static $authenticationScheme = \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
 
     public static $cacheManagerOptions = array();
 
@@ -204,7 +202,7 @@ class Client extends Magic
         $signer = "\\Stormpath\\Http\\Authc\\" . self::$authenticationScheme . "Signer";
 
         if(!class_exists($signer))
-            $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
+            $signer = "\\Stormpath\\Http\\Authc\\" . \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1 . "Signer";
 
         return $signer;
     }

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -109,7 +109,7 @@ class Client extends Magic
         self::$cacheManagerOptions = $cacheManagerOptions;
 
 //        $signer = $this->resolveSigner();
-        $signer = "Stormpath\\Http\\Authc\\SAuthc1Signer";
+        $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
 
         $requestExecutor = new HttpClientRequestExecutor(new $signer());
 

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -22,6 +22,7 @@ use Stormpath\DataStore\DefaultDataStore;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
+use Stormpath\Stormpath;
 use Stormpath\Util\Magic;
 
 function toObject($properties)
@@ -110,7 +111,8 @@ class Client extends Magic
 
 //        $signer = $this->resolveSigner();
         $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
-        $requestExecutor = new HttpClientRequestExecutor(new $signer);
+
+        $requestExecutor = new HttpClientRequestExecutor(new $signer());
 
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/ClientBuilder.php
+++ b/src/Stormpath/ClientBuilder.php
@@ -54,6 +54,7 @@ class ClientBuilder extends Magic
     private $cacheManager = NULL;
     private $cacheManagerOptions = array();
     private $baseURL;
+    private $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
 
     /**
      * Sets the location of the 'ini' file to load containing the API Key (Id and secret) used by the
@@ -220,6 +221,12 @@ class ClientBuilder extends Magic
         if(!$this->cacheManager) {
             $this->cacheManager = $this->qualifyCacheManager($this->cacheManagerOptions['cachemanager']);
         }
+        return $this;
+    }
+
+    public function setAuthenticationScheme($authenticationScheme)
+    {
+        $this->authenticationScheme = $authenticationScheme;
         return $this;
     }
 

--- a/src/Stormpath/ClientBuilder.php
+++ b/src/Stormpath/ClientBuilder.php
@@ -54,7 +54,7 @@ class ClientBuilder extends Magic
     private $cacheManager = NULL;
     private $cacheManagerOptions = array();
     private $baseURL;
-    private $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+    private $authenticationScheme = \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
 
     /**
      * Sets the location of the 'ini' file to load containing the API Key (Id and secret) used by the

--- a/src/Stormpath/ClientBuilder.php
+++ b/src/Stormpath/ClientBuilder.php
@@ -54,7 +54,7 @@ class ClientBuilder extends Magic
     private $cacheManager = NULL;
     private $cacheManagerOptions = array();
     private $baseURL;
-    private $authenticationScheme = \Stormpath\Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+    private $authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
 
     /**
      * Sets the location of the 'ini' file to load containing the API Key (Id and secret) used by the

--- a/src/Stormpath/Http/Authc/BasicSigner.php
+++ b/src/Stormpath/Http/Authc/BasicSigner.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Stormpath\Http\Authc;
+
+/*
+ * Copyright 2013 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+use Stormpath\ApiKey;
+use Stormpath\Http\Request;
+use Stormpath\Stormpath;
+
+class BasicSigner implements RequestSigner
+{
+    const AUTHORIZATION_HEADER   = 'Authorization';
+    const STORMPATH_DATE_HEADER  = 'X-Stormpath-Date';
+    const AUTHENTICATION_SCHEME  = Stormpath::AUTHENTICATION_SCHEME_BASIC;
+
+    const TIMESTAMP_FORMAT       = 'Ymd\THms\Z';
+    const TIME_ZONE              = 'UTC';
+
+    const NL                     = "\n";
+
+
+    public function signRequest(Request $request, ApiKey $apiKey)
+    {
+        date_default_timezone_set(self::TIME_ZONE);
+        $date = new \DateTime();
+        $timeStamp = $date->format(self::TIMESTAMP_FORMAT);
+
+        $requestHeaders = $request->getHeaders();
+
+        unset($requestHeaders[self::STORMPATH_DATE_HEADER]);
+        unset($requestHeaders[self::AUTHORIZATION_HEADER]);
+
+        $requestHeaders[self::STORMPATH_DATE_HEADER] = $timeStamp;
+
+        $authorizationHeader = base64_encode($apiKey->getId() . ":" . $apiKey->getSecret());
+
+        $requestHeaders[self::AUTHORIZATION_HEADER] = self::AUTHENTICATION_SCHEME . " " . $authorizationHeader;
+
+
+        $request->setHeaders($requestHeaders);
+
+
+    }
+}

--- a/src/Stormpath/Http/Authc/RequestSigner.php
+++ b/src/Stormpath/Http/Authc/RequestSigner.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stormpath\Http\Authc;
+
+/*
+ * Copyright 2013 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+use Stormpath\ApiKey;
+use Stormpath\Http\Request;
+
+interface RequestSigner {
+    public function signRequest(Request $request, ApiKey $apiKey);
+}

--- a/src/Stormpath/Http/Authc/Sauthc1Signer.php
+++ b/src/Stormpath/Http/Authc/Sauthc1Signer.php
@@ -20,10 +20,11 @@ namespace Stormpath\Http\Authc;
 
 use Stormpath\ApiKey;
 use Stormpath\Http\Request;
+use Stormpath\Stormpath;
 use Stormpath\Util\RequestUtils;
 use Stormpath\Util\UUID;
 
-class Sauthc1Signer
+class SAuthc1Signer implements RequestSigner
 {
     const DEFAULT_ENCODING       = 'UTF-8';
     const DEFAULT_ALGORITHM      = 'SHA256';
@@ -32,7 +33,7 @@ class Sauthc1Signer
     const STORMPATH_DATE_HEADER  = 'X-Stormpath-Date';
     const ID_TERMINATOR          = 'sauthc1_request';
     const ALGORITHM              = 'HMAC-SHA-256';
-    const AUTHENTICATION_SCHEME  = 'SAuthc1';
+    const AUTHENTICATION_SCHEME  = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
     const SAUTHC1_ID             = 'sauthc1Id';
     const SAUTHC1_SIGNED_HEADERS = 'sauthc1SignedHeaders';
     const SAUTHC1_SIGNATURE      = 'sauthc1Signature';

--- a/src/Stormpath/Http/HttpClientRequestExecutor.php
+++ b/src/Stormpath/Http/HttpClientRequestExecutor.php
@@ -22,21 +22,24 @@ namespace Stormpath\Http;
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\RequestInterface;
 use Stormpath\ApiKey;
-use Stormpath\Http\Authc\Sauthc1Signer;
+use Stormpath\Http\Authc\RequestSigner;
+use Stormpath\Stormpath;
 
 class HttpClientRequestExecutor implements RequestExecutor
 {
     private $httpClient;
     private $signer;
 
-    public function __construct()
+    public function __construct(RequestSigner $signer)
     {
         $this->httpClient = new Client();
-        $this->signer = new Sauthc1Signer;
+        $this->signer = $signer;
     }
+
 
     public function executeRequest(Request $request, $redirectsLimit = 10)
     {
+
         $requestHeaders = $request->getHeaders();
         $apiKey = $request->getApiKey();
 

--- a/src/Stormpath/Http/HttpClientRequestExecutor.php
+++ b/src/Stormpath/Http/HttpClientRequestExecutor.php
@@ -91,5 +91,10 @@ class HttpClientRequestExecutor implements RequestExecutor
         }
     }
 
+    public function getSigner()
+    {
+        return $this->signer;
+    }
+
 
 }

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -22,6 +22,7 @@ namespace Stormpath;
 use Stormpath\Client;
 
 function Stormpath_autoload($className) {
+    var_dump($className);
     if (substr($className, 0, 9) != 'Stormpath') {
         return false;
     }
@@ -30,7 +31,7 @@ function Stormpath_autoload($className) {
 }
 // @codeCoverageIgnoreEnd
 
-spl_autoload_register('Stormpath\Stormpath_autoload');
+//spl_autoload_register('Stormpath\Stormpath_autoload');
 
 class Stormpath
 {

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -80,6 +80,9 @@ class Stormpath
     const ASCENDING                             = 'asc';
     const DESCENDING                            = 'desc';
 
+    const AUTHENTICATION_SCHEME_BASIC           = 'Basic';
+    const AUTHENTICATION_SCHEME_SAUTHC1         = 'SAuthc1';
+
     public static $Statuses             = array(self::DISABLED => self::DISABLED,
                                             self::ENABLED => self::ENABLED);
 

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -21,16 +21,16 @@ namespace Stormpath;
 // @codeCoverageIgnoreStart
 use Stormpath\Client;
 
-//function Stormpath_autoload($className) {
-//    if (substr($className, 0, 9) != 'Stormpath') {
-//        return false;
-//    }
-//    $file = str_replace('\\', '/', $className);
-//    return include dirname(__FILE__) . "$file";
-//}
+function Stormpath_autoload($className) {
+    if (substr($className, 0, 9) != 'Stormpath') {
+        return false;
+    }
+    $file = str_replace('\\', '/', $className);
+    return include dirname(__FILE__) . "$file";
+}
 // @codeCoverageIgnoreEnd
 
-//spl_autoload_register('Stormpath\Stormpath_autoload');
+spl_autoload_register('Stormpath\Stormpath_autoload');
 
 class Stormpath
 {

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -21,16 +21,16 @@ namespace Stormpath;
 // @codeCoverageIgnoreStart
 use Stormpath\Client;
 
-function Stormpath_autoload($className) {
-    if (substr($className, 0, 9) != 'Stormpath') {
-        return false;
-    }
-    $file = str_replace('\\', '/', $className);
-    return include dirname(__FILE__) . "$file";
-}
+//function Stormpath_autoload($className) {
+//    if (substr($className, 0, 9) != 'Stormpath') {
+//        return false;
+//    }
+//    $file = str_replace('\\', '/', $className);
+//    return include dirname(__FILE__) . "$file";
+//}
 // @codeCoverageIgnoreEnd
 
-spl_autoload_register('Stormpath\Stormpath_autoload');
+//spl_autoload_register('Stormpath\Stormpath_autoload');
 
 class Stormpath
 {

--- a/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
@@ -1,0 +1,62 @@
+<?php
+namespace Stormpath\Tests\Http\Authc;
+
+use Stormpath\Stormpath;
+use Stormpath\Tests\BaseTest;
+
+class RequestSignerTest extends BaseTest
+{
+    public function setUp()
+    {
+        parent::setUp();
+        \Stormpath\Client::tearDown();
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_sign_a_request_with_basic_authorization_header()
+    {
+        \Stormpath\Client::$authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_BASIC;
+        $client = \Stormpath\Client::getInstance();
+
+        $this->assertInstanceOf('\\Stormpath\\Http\\Authc\\BasicSigner', $client->getDataStore()->getRequestExecutor()->getSigner());
+
+        $directory = $this->createDirectory();
+
+        $this->assertInstanceOf('\\Stormpath\\Resource\\Directory', $directory);
+
+        $directory->delete();
+
+
+
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_sign_a_request_with_sauthc1_authorization_header()
+    {
+        \Stormpath\Client::$authenticationScheme = Stormpath::AUTHENTICATION_SCHEME_SAUTHC1;
+        $client = \Stormpath\Client::getInstance();
+
+        $this->assertInstanceOf('\\Stormpath\\Http\\Authc\\SAuthc1Signer', $client->getDataStore()->getRequestExecutor()->getSigner());
+
+        $directory = $this->createDirectory();
+
+        $this->assertInstanceOf('\\Stormpath\\Resource\\Directory', $directory);
+
+        $directory->delete();
+
+
+
+    }
+
+    private function createDirectory()
+    {
+        $directory = \Stormpath\Resource\Directory::instantiate(array('name' => 'Main Directory' .md5(time().microtime().uniqid()), 'description' => 'Main Directory description'));
+        return self::createResource(\Stormpath\Resource\Directory::PATH, $directory);
+    }
+
+}
+

--- a/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
@@ -52,6 +52,16 @@ class RequestSignerTest extends BaseTest
 
     }
 
+    /**
+     * @test
+     */
+    public function it_defaults_to_sauthc1()
+    {
+        $client = \Stormpath\Client::getInstance();
+        $this->assertInstanceOf('\\Stormpath\\Http\\Authc\\SAuthc1Signer', $client->getDataStore()->getRequestExecutor()->getSigner());
+
+    }
+
     private function createDirectory()
     {
         $directory = \Stormpath\Resource\Directory::instantiate(array('name' => 'Main Directory' .md5(time().microtime().uniqid()), 'description' => 'Main Directory description'));

--- a/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
@@ -3,6 +3,8 @@ namespace Stormpath\Tests\Http\Authc;
 
 use Stormpath\Stormpath;
 use Stormpath\Tests\BaseTest;
+use Stormpath\Http\Authc\BasicSigner;
+use Stormpath\Http\Authc\SAuthc1Signer;
 
 class RequestSignerTest extends BaseTest
 {


### PR DESCRIPTION
This adds a way to specify the Authentication Request Signer to help with the issues for when you do not have control of your applications request header, such as Google Apps Engine.  

This PR addresses and fixes #12 

Waiting on review from @ecrisostomo 