### PR TITLE
Allow setting Authentication Request Signer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ before_script:
 - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
-install:
- - composer require satooshi/php-coveralls:~0.6@stable
+# install:
+ # - composer require satooshi/php-coveralls:~0.6@stable
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'
+  # - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ before_script:
 - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
-# install:
- # - composer require satooshi/php-coveralls:~0.6@stable
+install:
+ - composer require satooshi/php-coveralls:~0.6@stable
 
 script:
   - vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
 after_success:
-  # - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php vendor/bin/coveralls -v; fi;'
 

--- a/README.md
+++ b/README.md
@@ -382,6 +382,38 @@ Array caching system.
     
 Then you would call it the same way you do for a cache manager normally.  
 
+### Authentication Scheme Configuration
+ 
+You can choose one of two authentication schemes to authenticate with Stormpath:
+ 
+ - Stormpath SAuthc1 Authentication: This is the recommended approach, and the default setting. This 
+ approach computes a cryptographic digest of the request and sends the digest value along with the 
+ request. If the transmitted digest matches what the Stormpath API server computes for the same 
+ request, the request is authenticated. The Stormpath SAuthc1 digest-based authentication 
+ scheme is more secure than standard HTTP digest authentication.
+ 
+ - Basic Authentication: This is only recommended when your application runs in an environment outside 
+ of your control, and that environment manipulates your application’s request headers when requests 
+ are made. Google App Engine is one known such environment. However, Basic Authentication is not 
+ as secure as Stormpath’s SAuthc algorithm, so only use this if you are forced to do so by your 
+ application runtime environement.
+ 
+When no authentication scheme is explicitly configured, Sauthc1 is used by default.
+ 
+If you must change to basic authentication for these special environments, set the authenticationScheme 
+property using Stormpath::AUTHENTICATION_SCHEME_BASIC or Stormpath::AUTHENTICATION_SCHEME_SAUTHC1:
+
+```php
+     \Stormpath\Client::$authenticationScheme = 'Stormpath::AUTHENTICATION_SCHEME_BASIC';
+```
+OR
+ 
+```php
+      $builder = new \Stormpath\ClientBuilder();
+      $client = $builder->setAuthenticationScheme(Stormpath::AUTHENTICATION_SCHEME_BASIC)
+                     ->build();
+```
+
 ### Accessing Resources
 
 Most of the work you do with Stormpath is done through the applications

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,7 +19,6 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
-use Stormpath\Http\Authc\Sauthc1Signer;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
@@ -107,7 +106,8 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $requestExecutor = new HttpClientRequestExecutor(new Sauthc1Signer);
+        $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SAUTHC1 . "Signer";
+        $requestExecutor = new HttpClientRequestExecutor(new $signer);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);
     }

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -106,7 +106,7 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $signer = "Stormpath\\Http\\Authc\\SAuthc1Signer";
+        $signer = "\\Stormpath\\Http\\Authc\\SAuthc1Signer";
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -106,7 +106,7 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $signer = "\\Stormpath\\Http\\Authc\\" . Stormpath::AUTHENTICATION_SAUTHC1 . "Signer";
+        $signer = "Stormpath\\Http\\Authc\\SAuthc1SignerSigner";
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -19,6 +19,7 @@ namespace Stormpath;
  */
 
 use Stormpath\DataStore\DefaultDataStore;
+use Stormpath\Http\Authc\Sauthc1Signer;
 use Stormpath\Http\HttpClientRequestExecutor;
 use Stormpath\Resource\Resource;
 use Stormpath\Stormpath;
@@ -106,7 +107,7 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $requestExecutor = new HttpClientRequestExecutor();
+        $requestExecutor = new HttpClientRequestExecutor(new Sauthc1Signer);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);
     }

--- a/src/Stormpath/Client.php
+++ b/src/Stormpath/Client.php
@@ -106,7 +106,7 @@ class Client extends Magic
         self::$cacheManager = $cacheManager;
         self::$cacheManagerOptions = $cacheManagerOptions;
 
-        $signer = "Stormpath\\Http\\Authc\\SAuthc1SignerSigner";
+        $signer = "Stormpath\\Http\\Authc\\SAuthc1Signer";
         $requestExecutor = new HttpClientRequestExecutor(new $signer);
         $this->cacheManagerInstance = new self::$cacheManager($cacheManagerOptions);
         $this->dataStore = new DefaultDataStore($requestExecutor, $apiKey, $this->cacheManagerInstance, $baseUrl);

--- a/src/Stormpath/Http/Authc/Sauthc1Signer.php
+++ b/src/Stormpath/Http/Authc/Sauthc1Signer.php
@@ -23,7 +23,7 @@ use Stormpath\Http\Request;
 use Stormpath\Util\RequestUtils;
 use Stormpath\Util\UUID;
 
-class Sauthc1Signer
+class SAuthc1Signer
 {
     const DEFAULT_ENCODING       = 'UTF-8';
     const DEFAULT_ALGORITHM      = 'SHA256';

--- a/src/Stormpath/Http/HttpClientRequestExecutor.php
+++ b/src/Stormpath/Http/HttpClientRequestExecutor.php
@@ -22,17 +22,16 @@ namespace Stormpath\Http;
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\RequestInterface;
 use Stormpath\ApiKey;
-use Stormpath\Http\Authc\Sauthc1Signer;
 
 class HttpClientRequestExecutor implements RequestExecutor
 {
     private $httpClient;
     private $signer;
 
-    public function __construct()
+    public function __construct($signer)
     {
         $this->httpClient = new Client();
-        $this->signer = new Sauthc1Signer;
+        $this->signer = $signer;
     }
 
     public function executeRequest(Request $request, $redirectsLimit = 10)

--- a/src/Stormpath/Http/HttpClientRequestExecutor.php
+++ b/src/Stormpath/Http/HttpClientRequestExecutor.php
@@ -87,5 +87,10 @@ class HttpClientRequestExecutor implements RequestExecutor
         }
     }
 
+    public function getSigner()
+    {
+        return $this->signer;
+    }
+
 
 }

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -80,6 +80,8 @@ class Stormpath
     const ASCENDING                             = 'asc';
     const DESCENDING                            = 'desc';
 
+    const AUTHENTICATION_SAUTHC1                = 'SAuthc1';
+
     public static $Statuses             = array(self::DISABLED => self::DISABLED,
                                             self::ENABLED => self::ENABLED);
 

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -18,6 +18,20 @@ namespace Stormpath;
  * limitations under the License.
  */
 
+// @codeCoverageIgnoreStart
+use Stormpath\Client;
+
+function Stormpath_autoload($className) {
+    if (substr($className, 0, 9) != 'Stormpath') {
+        return false;
+    }
+    $file = str_replace('\\', '/', $className);
+    return include dirname(__FILE__) . "$file";
+}
+// @codeCoverageIgnoreEnd
+
+spl_autoload_register('Stormpath\Stormpath_autoload');
+
 class Stormpath
 {
     const ACCOUNT                               = 'Account';

--- a/src/Stormpath/Stormpath.php
+++ b/src/Stormpath/Stormpath.php
@@ -18,20 +18,6 @@ namespace Stormpath;
  * limitations under the License.
  */
 
-// @codeCoverageIgnoreStart
-use Stormpath\Client;
-
-function Stormpath_autoload($className) {
-    if (substr($className, 0, 9) != 'Stormpath') {
-        return false;
-    }
-    $file = str_replace('\\', '/', $className);
-    return include dirname(__FILE__) . "$file";
-}
-// @codeCoverageIgnoreEnd
-
-spl_autoload_register('Stormpath\Stormpath_autoload');
-
 class Stormpath
 {
     const ACCOUNT                               = 'Account';

--- a/tests/Stormpath/Tests/ClientTest.php
+++ b/tests/Stormpath/Tests/ClientTest.php
@@ -71,5 +71,12 @@ class ClientTest extends BaseTest {
 
     }
 
+    public function testClientWillBeConstructedWithSAuthc1ByDefault()
+    {
+        \Stormpath\Client::tearDown();
+        $client = \Stormpath\Client::getInstance();
+        $this->assertInstanceOf('Stormpath\Http\Authc\SAuthc1Signer', $client->getDataStore()->getRequestExecutor()->getSigner());
+    }
+
 
 }


### PR DESCRIPTION
This adds a way to specify the Authentication Request Signer to help with the issues for when you do not have control of your applications request header, such as Google Apps Engine.

This PR addresses and fixes #12