### PR TITLE
Cleaned up the Client in regards to the Cache Manager and Parameters

### DIFF
--- a/src/Stormpath/ClientBuilder.php
+++ b/src/Stormpath/ClientBuilder.php
@@ -17,6 +17,7 @@ namespace Stormpath;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use Stormpath\Cache\CacheManager;
 use Stormpath\Cache\Exceptions\InvalidCacheManagerException;
 use Stormpath\Http\Authc\SAuthc1RequestSigner;
 use Stormpath\Http\DefaultRequest;
@@ -52,7 +53,7 @@ class ClientBuilder extends Magic
     private $apiKeySecretPropertyName = "apiKey.secret";
     private $apiKeyProperties;
     private $apiKeyFileLocation;
-    private $cacheManager = NULL;
+    private $cacheManager = null;
     private $cacheManagerOptions = array();
     private $baseURL;
     private $authenticationScheme = Stormpath::SAUTHC1_AUTHENTICATION_SCHEME;
@@ -211,8 +212,8 @@ class ClientBuilder extends Magic
 
     public function setCacheManager($cacheManager)
     {
+        if (!$cacheManager) $cacheManager = 'Array';
         $this->cacheManager = $this->qualifyCacheManager($cacheManager);
-
         return $this;
     }
 
@@ -386,24 +387,16 @@ class ClientBuilder extends Magic
 
     private function qualifyCacheManager($cacheManager)
     {
-        if (is_object($cacheManager))
+        if ($this->isFullyQualifiedCacheManager($cacheManager))
             return $cacheManager;
 
-        $notCoreClass = true;
+        $cacheManagerPath = "Stormpath\\Cache\\{$cacheManager}CacheManager";
 
-        if(class_exists($cacheManager))
-            $notCoreClass = class_implements($cacheManager) == 'Stormpath\Cache\CacheManager';
-
-        if(class_exists($cacheManager) && $notCoreClass) return $cacheManager;
-
-        if(strpos($cacheManager, 'CacheManager')) {
-            $cacheManagerPath = "{$cacheManager}";
-        } else {
-            $cacheManagerPath = "Stormpath\\Cache\\{$cacheManager}CacheManager";
-        }
+        if(class_exists($cacheManagerPath))
+            return $cacheManagerPath;
 
 
-        if(class_exists($cacheManagerPath)) return $cacheManagerPath;
+        throw new \InvalidArgumentException("Could not qualify cache manager $cacheManagerPath");
 
     }
 
@@ -416,5 +409,10 @@ class ClientBuilder extends Magic
 
         return new $signer;
 
+    }
+
+    private function isFullyQualifiedCacheManager($cacheManager)
+    {
+        return is_object($cacheManager) && $cacheManager instanceof CacheManager;
     }
 }

--- a/src/Stormpath/ClientBuilder.php
+++ b/src/Stormpath/ClientBuilder.php
@@ -285,13 +285,14 @@ class ClientBuilder extends Magic
 
         $apiKey = new ApiKey($apiKeyId, $apiKeySecret);
 
+        $cacheManager = new $this->cacheManager($this->cacheManagerOptions);
+
         $signer = $this->resolveSigner();
         $requestSigner = new $signer;
 
         return new Client(
             $apiKey,
-            $this->cacheManager,
-            $this->cacheManagerOptions,
+            $cacheManager,
             $this->baseURL,
             $requestSigner
         );
@@ -385,6 +386,9 @@ class ClientBuilder extends Magic
 
     private function qualifyCacheManager($cacheManager)
     {
+        if (is_object($cacheManager))
+            return $cacheManager;
+
         $notCoreClass = true;
 
         if(class_exists($cacheManager))

--- a/src/Stormpath/DataStore/DefaultDataStore.php
+++ b/src/Stormpath/DataStore/DefaultDataStore.php
@@ -19,6 +19,7 @@ namespace Stormpath\DataStore;
  */
 
 use Stormpath\ApiKey;
+use Stormpath\Cache\ArrayCacheManager;
 use Stormpath\Cache\Cacheable;
 use Stormpath\Http\DefaultRequest;
 use Stormpath\Http\Request;
@@ -47,7 +48,12 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
     {
         $this->requestExecutor = $requestExecutor;
         $this->resourceFactory = new DefaultResourceFactory($this);
+
         $this->cacheManager = $cacheManager;
+
+        if ($this->cacheManager == null) {
+            $this->cacheManager = new ArrayCacheManager(array());
+        }
         $this->cache = $this->cacheManager->getCache();
 
         $this->apiKey = $apiKey;

--- a/tests/Stormpath/Tests/ClientTest.php
+++ b/tests/Stormpath/Tests/ClientTest.php
@@ -71,5 +71,16 @@ class ClientTest extends BaseTest {
 
     }
 
+    public function testClientInstanceDefaultsCacheIfNoCacheItemsAreSetWhenCalledDirectly()
+    {
+        \Stormpath\Client::tearDown();
+        $apiKey = new \Stormpath\ApiKey('id','secret');
+
+        $client = new \Stormpath\Client($apiKey);
+
+        $this->assertInstanceOf('Stormpath\Cache\ArrayCacheManager', $client->getCacheManager());
+
+    }
+
 
 }

--- a/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Stormpath/Tests/Http/Authc/RequestSignerTest.php
@@ -81,9 +81,9 @@ class RequestSignerTest extends BaseTest
     public function it_can_set_authentication_scheme_if_client_called_directly()
     {
         $apiKey = new \Stormpath\ApiKey('id','secret');
-        $cacheManager = '\\Stormpath\\Cache\\NullCacheManager';
+        $cacheManager = new \Stormpath\Cache\NullCacheManager(array());
         $signer = '\\Stormpath\\Http\\Authc\\'.Stormpath::BASIC_AUTHENTICATION_SCHEME.'RequestSigner';
-        $client = new \Stormpath\Client($apiKey, $cacheManager, array(), null, new $signer);
+        $client = new \Stormpath\Client($apiKey, $cacheManager, null, new $signer);
 
         $this->assertInstanceOf('\\Stormpath\\Http\\Authc\\BasicRequestSigner', $client->getDataStore()->getRequestExecutor()->getSigner());
         $client->tearDown();
@@ -95,9 +95,9 @@ class RequestSignerTest extends BaseTest
     public function it_will_default_to_suthc1_if_client_called_directly()
     {
         $apiKey = new \Stormpath\ApiKey('id','secret');
-        $cacheManager = '\\Stormpath\\Cache\\NullCacheManager';
+        $cacheManager = new \Stormpath\Cache\NullCacheManager(array());
 
-        $client = new \Stormpath\Client($apiKey, $cacheManager, array());
+        $client = new \Stormpath\Client($apiKey, $cacheManager);
 
         $this->assertInstanceOf('\\Stormpath\\Http\\Authc\\SAuthc1RequestSigner', $client->getDataStore()->getRequestExecutor()->getSigner());
         $client->tearDown();


### PR DESCRIPTION
You no longer are required to pass in the Cache Manager and Cache Manager Options to the client if instantiating the Client directly.