### PR TITLE
Adjust Password Reset Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,9 @@ registered on, can be kicked off with the
 ```php
 // this method returns the account
 $account = $application->sendPasswordResetEmail('super_unique_email@unknown123.kot');
+
+// if you want the SP Token to be returned
+$account = $application->sendPasswordResetEmail('super_unique_email@unknown123.kot', [], true);
 ```
 
 Alternatively, if you know the account store where the account matching the 
@@ -996,14 +999,12 @@ method on the application.
 ```php
 // this method returns the account
 $account = $application->verifyPasswordResetToken('the_token_from_query_string');
-end
 ```
 
 With the account acquired you can then update the password:
 
 ```php
-  $account->password = 'new_password';
-  $account->save();
+  $account = $application->resetPassword($sptoken, $newPassword);
 ```
 
 _NOTE :_ Confirming a new password is left up to the web application

--- a/src/Resource/Application.php
+++ b/src/Resource/Application.php
@@ -200,9 +200,12 @@ class Application extends InstanceResource implements Deletable
      * @return the account corresponding to the specified username or email address.
      * @see #verifyPasswordResetToken()
      */
-    public function sendPasswordResetEmail($accountUsernameOrEmail, array $options = array())
+    public function sendPasswordResetEmail($accountUsernameOrEmail, array $options = array(), $returnTokenResource = false)
     {
         $passwordResetToken = $this->createPasswordResetToken($accountUsernameOrEmail, $options);
+
+        if ($returnTokenResource)
+            return $passwordResetToken;
 
         return $passwordResetToken->getAccount();
     }
@@ -259,6 +262,19 @@ class Application extends InstanceResource implements Deletable
         return $passwordResetToken->getAccount($options);
     }
     // @codeCoverageIgnoreStart
+
+    public function resetPassword($token, $password)
+    {
+        $href = $this->getPasswordResetTokensHref();
+        $href .= '/' .$token;
+
+        $passwordResetProps = new PasswordResetToken();
+        $passwordResetProps->password = $password;
+
+        $token = $this->getDataStore()->create($href, $passwordResetProps, Stormpath::PASSWORD_RESET_TOKEN);
+
+        return $token->getAccount();
+    }
 
     /**
      * Authenticates an account's submitted principals and credentials (e.g. username and password).  The account must

--- a/src/Resource/PasswordResetToken.php
+++ b/src/Resource/PasswordResetToken.php
@@ -25,6 +25,7 @@ class PasswordResetToken extends Resource
     const EMAIL = "email";
     const ACCOUNT = "account";
     const ACCOUNT_STORE = "accountStore";
+    const PASSWORD = "password";
 
     // @codeCoverageIgnoreStart
     public function getEmail()
@@ -46,5 +47,15 @@ class PasswordResetToken extends Resource
     public function setAccountStore($accountStore)
     {
         $this->setProperty(self::ACCOUNT_STORE, $accountStore);
+    }
+
+    public function setPassword($password)
+    {
+        $this->setProperty(self::PASSWORD, $password);
+    }
+
+    public function getPassword()
+    {
+        $this->getProperty(self::PASSWORD);
     }
 }


### PR DESCRIPTION
Fix Password Reset Workflow to trigger the reset password success email to be sent.

Adds a boolean to return sp token for `sendPasswordResetEmail` method instead of the account

Fixes #102 and Fixes #103