### PR TITLE
Hotfix/release 1.12.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,19 @@
 stormpath-sdk-php Changelog
 ===========================
 
+Version 1.12.1
+--------------
+
+Released on December 15, 2015
+
+ - Social Providers isNewAccount was always returning null.  This has been fixed (Fixes Issue #109)
+ - Handle ID Site would throw new exception if account was not valid, This prevented you from accessing state or any other properties
+ You can not access all properties, and account will just remain null. (Fixes Issue #110)
+ - Documentation issue on API Keys and Account for Request Authenticators. (Fixes Issue #105)
+ - Update the Base Test so it is not treated as a test. 
+
 Version 1.12.0
-------------------
+--------------
 
 Released on November 5, 2015
 

--- a/README.md
+++ b/README.md
@@ -1834,10 +1834,10 @@ The `Authorization` header contains a base64 encoding of the API Key and Secret.
 $application = \Stormpath\Resource\Application::get("https://api.stormpath.com/v1/applications/24mp4us71ntza6lBwlu");
 
 $request = \Stormpath\Authc\Api\Request::createFromGlobals();
-$result = new ApiRequestAuthenticator($application)->authenticate($request);
+$result = (new ApiRequestAuthenticator($application))->authenticate($request);
 
-$account = $result->account;
-$apiKey = $result->apiKey;
+$account = $result->getApiKey()->account;
+$apiKey = $result->getApiKey();
 ```
 
 ##### Using `BasicRequestAuthenticator`
@@ -1846,10 +1846,10 @@ $apiKey = $result->apiKey;
 $application = \Stormpath\Resource\Application::get("https://api.stormpath.com/v1/applications/24mp4us71ntza6lBwlu");
 
 $request = \Stormpath\Authc\Api\Request::createFromGlobals();
-$result = new BasicRequestAuthenticator($application)->authenticate($request);
+$result = (new BasicRequestAuthenticator($application))->authenticate($request);
 
-$account = $result->account;
-$apiKey = $result->apiKey;
+$account = $result->getApiKey()->account;
+$apiKey = $result->getApiKey();
 ```
 
 ### OAuth Authentication
@@ -1908,10 +1908,10 @@ Host: api.trooperapp.com
 $application = \Stormpath\Resource\Application::get("https://api.stormpath.com/v1/applications/24mp4us71ntza6lBwlu");
 
 $request = \Stormpath\Authc\Api\Request::createFromGlobals();
-$result = new OAuthRequestAuthenticator($application)->authenticate($request);
+$result = (new OAuthRequestAuthenticator($application))->authenticate($request);
 
-$account = $result->account;
-$apiKey = $result->apiKey;
+$account = $result->getApiKey()->account;
+$apiKey = $result->getApiKey();
 ```
 
 You can also use the more specific `OAuthBearerRequestAuthenticator` to authenticate 

--- a/src/Resource/Application.php
+++ b/src/Resource/Application.php
@@ -406,10 +406,14 @@ class Application extends InstanceResource implements Deletable
 
         $nonceStore->putNonce($jwt->irt);
 
-
-        $account = $this->getDataStore()->getResource($jwt->sub, Stormpath::ACCOUNT);
-
         $return = new \StdClass();
+
+        try {
+            $account = $this->getDataStore()->getResource($jwt->sub, Stormpath::ACCOUNT);
+        } catch (\Stormpath\Resource\ResourceError $re) {
+            $account = null;
+        }
+
 
         $return->account = $account;
         $return->state = $jwt->state;

--- a/src/Resource/ProviderAccountResult.php
+++ b/src/Resource/ProviderAccountResult.php
@@ -23,7 +23,7 @@ use Stormpath\Stormpath;
 class ProviderAccountResult extends Resource
 {
     const ACCOUNT       = 'account';
-    const NEW_ACCOUNT   = 'newAccount';
+    const NEW_ACCOUNT   = 'isNewAccount';
     
     public function __construct($dataStore = null, \stdClass $properties = null, array $options = array())
     {

--- a/src/Util/Version.php
+++ b/src/Util/Version.php
@@ -20,6 +20,6 @@ namespace Stormpath\Util;
 
 class Version
 {
-    const SDK_VERSION = '1.12.0';
+    const SDK_VERSION = '1.12.1';
 
 }

--- a/tests/Authc/Api/ApiRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/ApiRequestAuthenticatorTest.php
@@ -3,9 +3,9 @@ namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\ApiRequestAuthenticator;
 use Stormpath\Authc\Api\Request;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class ApiRequestAuthenticatorTest extends BaseTest
+class ApiRequestAuthenticatorTest extends TestCase
 {
 
     public static $account;

--- a/tests/Authc/Api/BasicRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/BasicRequestAuthenticatorTest.php
@@ -3,9 +3,9 @@ namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\BasicRequestAuthenticator;
 use Stormpath\Authc\Api\Request;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class BasicRequestAuthenticatorTest extends BaseTest
+class BasicRequestAuthenticatorTest extends TestCase
 {
 
     public static $account;

--- a/tests/Authc/Api/OAuthBearerRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthBearerRequestAuthenticatorTest.php
@@ -5,9 +5,9 @@ use Stormpath\Authc\Api\OAuthBearerAuthenticationResult;
 use Stormpath\Authc\Api\OAuthBearerRequestAuthenticator;
 use Stormpath\Authc\Api\OAuthClientCredentialsRequestAuthenticator;
 use Stormpath\Authc\Api\Request;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class OAuthBearerRequestAuthenticatorTest extends BaseTest
+class OAuthBearerRequestAuthenticatorTest extends TestCase
 {
 
     public static $account;

--- a/tests/Authc/Api/OAuthClientCredentialsAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthClientCredentialsAuthenticatorTest.php
@@ -4,9 +4,9 @@ namespace Stormpath\Tests\Authc\Api;
 use Stormpath\Authc\Api\OAuthClientCredentialsRequestAuthenticator;
 use Stormpath\Authc\Api\Request;
 use Stormpath\Exceptions\RequestAuthenticatorException;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class OAuthClientCredentialsAuthenticationTest extends BaseTest
+class OAuthClientCredentialsAuthenticationTest extends TestCase
 {
 
     public static $account;

--- a/tests/Authc/Api/OAuthPasswordRequestAuthenticatorRequest.php
+++ b/tests/Authc/Api/OAuthPasswordRequestAuthenticatorRequest.php
@@ -2,9 +2,9 @@
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\OAuthPasswordRequestAuthenticator;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class OAuthPasswordAuthenticationResult extends BaseTest
+class OAuthPasswordAuthenticationResult extends TestCase
 {
     public static $account;
 

--- a/tests/Authc/Api/OAuthRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthRequestAuthenticatorTest.php
@@ -4,9 +4,9 @@ namespace Stormpath\Tests\Authc\Api;
 use Stormpath\Authc\Api\OAuthPasswordRequestAuthenticator;
 use Stormpath\Authc\Api\OAuthRequestAuthenticator;
 use Stormpath\Authc\Api\Request;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class OAuthRequestAuthenticatorTest extends BaseTest
+class OAuthRequestAuthenticatorTest extends TestCase
 {
 
     public static $account;

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -2,9 +2,9 @@
 
 
 use Stormpath\Cache\Cacheable;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class CacheTest extends BaseTest
+class CacheTest extends TestCase
 {
 
     private static $application;

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,7 +1,7 @@
 <?php namespace Stormpath\Tests;
 
 
-class ClientTest extends BaseTest {
+class ClientTest extends TestCase {
 
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Http/Authc/RequestSignerTest.php
@@ -2,9 +2,9 @@
 namespace Stormpath\Tests\Http\Authc;
 
 use Stormpath\Stormpath;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class RequestSignerTest extends BaseTest
+class RequestSignerTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Oauth/PasswordRefreshGrantTest.php
+++ b/tests/Oauth/PasswordRefreshGrantTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class PasswordRefreshGrantTest extends \Stormpath\Tests\BaseTest
+class PasswordRefreshGrantTest extends \Stormpath\Tests\TestCase
 {
     private static $application;
     private static $account;

--- a/tests/Resource/AccountCreationPolicyTest.php
+++ b/tests/Resource/AccountCreationPolicyTest.php
@@ -5,7 +5,7 @@ namespace Stormpath\Tests\Resource;
 
 use Stormpath\Stormpath;
 
-class AccountCreationPolicyTest extends \Stormpath\Tests\BaseTest {
+class AccountCreationPolicyTest extends \Stormpath\Tests\TestCase {
 
     private static $directory;
 

--- a/tests/Resource/AccountStoreMappingTest.php
+++ b/tests/Resource/AccountStoreMappingTest.php
@@ -18,7 +18,7 @@
 namespace Stormpath\Tests\Resource;
 
 
-class AccountStoreMappingTest extends \Stormpath\Tests\BaseTest {
+class AccountStoreMappingTest extends \Stormpath\Tests\TestCase {
 
     private static $application;
     private static $directory;
@@ -65,6 +65,7 @@ class AccountStoreMappingTest extends \Stormpath\Tests\BaseTest {
         {
             self::$directory->delete();
         }
+        parent::tearDownAfterClass();
     }
 
     public function testGet()

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -20,7 +20,7 @@ namespace Stormpath\Tests\Resource;
 use Stormpath\Client;
 use Stormpath\Stormpath;
 
-class AccountTest extends \Stormpath\Tests\BaseTest {
+class AccountTest extends \Stormpath\Tests\TestCase {
 
     const GROUPS_COUNT = 45;
 
@@ -74,6 +74,7 @@ class AccountTest extends \Stormpath\Tests\BaseTest {
         {
             self::$directory->delete();
         }
+        parent::tearDownAfterClass();
     }
 
     public function testGet() {

--- a/tests/Resource/ApplicationTest.php
+++ b/tests/Resource/ApplicationTest.php
@@ -175,7 +175,6 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
 
     /**
      * @test
-     * @expectedException \Stormpath\Resource\ResourceError
      */
     public function itDoesNotThrowIDSiteExceptionIfErrIsNotPresent()
     {
@@ -184,19 +183,45 @@ class ApplicationTest extends \Stormpath\Tests\BaseTest {
         // Create JWT Response with error
         $jwt = JWT::encode(
             array(
-                'jti'=>'123123123',
-                'iat'=>time(),
-                'iss'=>'https://api.stormpath.com/v1/applications/someAppUidHere',
-                'exp'=>time()+3600,
-                'irt'=>'123123',
-                'sub'=>self::$account
+                "iss" => "https://formal-ring.id.stormpath.io",
+                'sub'=>self::$account,
+                "aud" => "1PN3FXI0U79E2MHCF6XUYGU4Z",
+                "exp" => time()+100,
+                "iat" => 1450221187,
+                "jti" => "37Vljw5YV0dTNNP3V4h0SY",
+                "irt" => "370640ef-ea7c-4532-94ed-b55dc7fa006a",
+                "state" => "",
+                "isNewSub" => false,
+                "status" => "LOGOUT"
             ),
             $apiSecret
         );
 
-        // Handle ID Site Response
-        // This will throw resource error but we are good if we get there because it got past err check
         self::$application->handleIdSiteCallback('http://example.com?jwtResponse='.$jwt);
+    }
+
+    /** @test */
+    public function itWillReturnNullInAccountIfLoggedOut()
+    {
+        $apiSecret = Client::getInstance()->getDataStore()->getApiKey()->getSecret();
+        $jwt = JWT::encode(
+            [
+                "iss" => "https://formal-ring.id.stormpath.io",
+                "sub" => null,
+                "aud" => "1PN3FXI0U79E2MHCF6XUYGU4Z",
+                "exp" => time()+100,
+                "iat" => 1450221187,
+                "jti" => "37Vljw5YV0dTNNP3V4h0SY",
+                "irt" => "370640ef-ea7c-4532-94ed-b55dc7fa006a",
+                "state" => "",
+                "isNewSub" => false,
+                "status" => "LOGOUT"
+            ],
+            $apiSecret
+        );
+
+        $result = self::$application->handleIdSiteCallback('http://example.com?jwtResponse='.$jwt);
+        $this->assertNull($result->account);
     }
 
     protected function createAccount()

--- a/tests/Resource/DirectoryTest.php
+++ b/tests/Resource/DirectoryTest.php
@@ -20,7 +20,7 @@ namespace Stormpath\Tests\Resource;
 
 use Stormpath\Stormpath;
 
-class DirectoryTest extends \Stormpath\Tests\BaseTest {
+class DirectoryTest extends \Stormpath\Tests\TestCase {
 
     private static $directory;
     private static $inited;
@@ -46,6 +46,7 @@ class DirectoryTest extends \Stormpath\Tests\BaseTest {
         {
             self::$directory->delete();
         }
+        parent::tearDownAfterClass();
     }
 
     public function testGet()

--- a/tests/Resource/GroupMembershipTest.php
+++ b/tests/Resource/GroupMembershipTest.php
@@ -18,7 +18,7 @@
 namespace Stormpath\Tests\Resource;
 
 
-class GroupMembershipTest extends \Stormpath\Tests\BaseTest {
+class GroupMembershipTest extends \Stormpath\Tests\TestCase {
 
     private static $directory;
     private static $group;
@@ -72,6 +72,8 @@ class GroupMembershipTest extends \Stormpath\Tests\BaseTest {
         {
             self::$directory->delete();
         }
+
+        parent::tearDownAfterClass();
     }
 
     public function testGet()

--- a/tests/Resource/GroupTest.php
+++ b/tests/Resource/GroupTest.php
@@ -20,7 +20,7 @@ namespace Stormpath\Tests\Resource;
 
 use Stormpath\Stormpath;
 
-class GroupTest extends \Stormpath\Tests\BaseTest {
+class GroupTest extends \Stormpath\Tests\TestCase {
 
     private static $directory;
     private static $group;
@@ -51,6 +51,8 @@ class GroupTest extends \Stormpath\Tests\BaseTest {
         {
             self::$directory->delete();
         }
+
+        parent::tearDownAfterClass();
     }
 
     public function testGet()

--- a/tests/Resource/OrganizationTest.php
+++ b/tests/Resource/OrganizationTest.php
@@ -9,9 +9,9 @@ use Stormpath\Resource\Application;
 use Stormpath\Resource\Organization;
 use Stormpath\Resource\Tenant;
 use Stormpath\Stormpath;
-use Stormpath\Tests\BaseTest;
+use Stormpath\Tests\TestCase;
 
-class OrganizationTest extends BaseTest
+class OrganizationTest extends TestCase
 {
 
     private static $organization = null;

--- a/tests/Resource/ProviderTest.php
+++ b/tests/Resource/ProviderTest.php
@@ -29,7 +29,7 @@ use Stormpath\Resource\LinkedInProvider;
 use Stormpath\Resource\Provider;
 use Stormpath\Stormpath;
 
-class ProviderTest extends \Stormpath\Tests\BaseTest
+class ProviderTest extends \Stormpath\Tests\TestCase
 {
     public function testGetGoogleProvider()
     {

--- a/tests/Resource/TenantTest.php
+++ b/tests/Resource/TenantTest.php
@@ -26,7 +26,7 @@ use Stormpath\Resource\LinkedInProvider;
 use Stormpath\Resource\Tenant;
 use Stormpath\Stormpath;
 
-class TenantTest extends \Stormpath\Tests\BaseTest {
+class TenantTest extends \Stormpath\Tests\TestCase {
 
     public function testGet()
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -19,7 +19,9 @@
 namespace Stormpath\Tests;
 
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+use Stormpath\Client;
+
+class TestCase extends \PHPUnit_Framework_TestCase
 {
     const STORMPATH_SDK_TEST_API_KEY_FILE_LOCATION = 'STORMPATH_SDK_TEST_API_KEY_FILE_LOCATION';
     const STORMPATH_SDK_TEST_API_KEY_ID = 'STORMPATH_SDK_TEST_API_KEY_ID';
@@ -80,7 +82,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
 
     /**
      * This function instantiates a new client but doesn't modify
-     * the BaseTest::$client variable.
+     * the TestCase::$client variable.
      */
     protected function newClientInstance()
     {
@@ -98,12 +100,6 @@ class BaseTest extends \PHPUnit_Framework_TestCase
         return $newClient;
     }
 
-    public function testClient()
-    {
-        self::$client = \Stormpath\Client::getInstance();
-        $this->assertInstanceOf('Stormpath\Client', self::$client);
-    }
-
     protected static function createResource($parentHref, \Stormpath\Resource\Resource $resource, array $options = array())
     {
 
@@ -117,5 +113,10 @@ class BaseTest extends \PHPUnit_Framework_TestCase
     }
 
 
+    public static function tearDownAfterClass()
+    {
+        self::$client = null;
+        Client::tearDown();
+    }
 
 }


### PR DESCRIPTION
 - Social Providers isNewAccount was always returning null.  This has been fixed (Fixes Issue #109)
 - Handle ID Site would throw new exception if account was not valid, This prevented you from accessing state or any other properties
 You can not access all properties, and account will just remain null. (Fixes Issue #110)
 - Documentation issue on API Keys and Account for Request Authenticators. (Fixes Issue #105)
 - Update the Base Test so it is not treated as a test. 