### PR TITLE
Hotfix/v1.12.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,17 @@
 stormpath-sdk-php Changelog
 ===========================
 
+Version 1.12.2
+--------------
+
+Released on December 16, 2015
+
+ - Fixed a bug where the accessToken and refreshTokens were not accessible from the Account
+ - We now show the refresh token object from OauthGrantAuthenticatorResult for all requests if enabled
+ - Removed logging from the phpunit tests. If code coverage is needed, you should now use the flag on phpunit
+ - Update Readme Documentation to reference the fixes and phpunit changes
+ - Removed branch alias from composer.json file
+
 Version 1.12.1
 --------------
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Codecov](https://img.shields.io/codecov/c/github/stormpath/stormpath-sdk-php.svg)](https://codecov.io/github/stormpath/stormpath-sdk-php)
 [![Total Downloads](https://poser.pugx.org/stormpath/sdk/d/total.svg)](https://packagist.org/packages/stormpath/sdk)
 [![Latest Stable Version](https://poser.pugx.org/stormpath/sdk/v/stable.svg)](https://packagist.org/packages/stormpath/sdk)
-[![Latest Unstable Version](https://poser.pugx.org/stormpath/sdk/v/unstable.svg)](https://packagist.org/packages/stormpath/sdk)
 [![License](https://poser.pugx.org/stormpath/sdk/license.svg)](https://packagist.org/packages/stormpath/sdk)
 
 # Stormpath PHP SDK
@@ -1942,8 +1941,11 @@ Alternatively, configure the api key id and secret and run the tests:
     export STORMPATH_SDK_TEST_API_KEY_SECRET=API_KEY_SECRET_VALUE
     vendor/bin/phpunit
 
-After running the tests, find the code coverage information
-in the following directory: <code>tests/code-coverage</code>
+If you would like code coverage, please run the tests with the following:
+    
+    vendor/bin/phpunit --coverage-html=./code-coverage
+    
+The code coverage will be placed in the root of the package in a folder named `code-coverage`.  Once you have this folder, you can open it in your browser to view it.
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -35,11 +35,6 @@
             "Stormpath\\Tests\\": "tests/"
         }
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.12-dev"
-        }
-    },
     "require": {
         "php": ">=5.4",
         "guzzle/guzzle": "3.9.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,15 +9,6 @@
         </testsuite>
     </testsuites>
 
-    <logging>
-        <log type="coverage-html" target="./code-coverage"  charset="UTF-8" yui="true" lowUpperBound="50" highLowerBound="90"/>
-        <log type="coverage-clover" target="./code-coverage/clover.xml"/>
-        <log type="coverage-crap4j" target="./code-coverage/crap4j.xml"/>
-        <log type="coverage-php" target="./code-coverage/coverage.php"/>
-        <log type="coverage-text" target="./code-coverage/coverage.txt"/>
-        <log type="junit" target="./code-coverage/junit.xml" logIncompleteSkipped="false"/>
-    </logging>
-
     <filter>
         <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>

--- a/src/Oauth/OauthGrantAuthenticationResultBuilder.php
+++ b/src/Oauth/OauthGrantAuthenticationResultBuilder.php
@@ -65,9 +65,7 @@ class OauthGrantAuthenticationResultBuilder
         $this->accessTokenHref = $this->grantAuthenticationToken->getAccessTokenHref();
         $this->tokenType = $this->grantAuthenticationToken->getTokenType();
         $this->expiresIn = $this->grantAuthenticationToken->getExpiresIn();
-
-        if ($this->isRefreshGrantAuthRequest)
-            $this->refreshToken = $this->grantAuthenticationToken->getAsRefreshToken();
+        $this->refreshToken = $this->grantAuthenticationToken->getAsRefreshToken();
 
         return new OauthGrantAuthenticationResult($this);
     }

--- a/src/Resource/AccessTokenList.php
+++ b/src/Resource/AccessTokenList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stormpath\Resource;
+
+/*
+ * Copyright 2013 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Stormpath\Stormpath;
+
+class AccessTokenList extends AbstractCollectionResource
+{
+    function getItemClassName()
+    {
+        return Stormpath::ACCESS_TOKEN;
+    }
+
+}

--- a/src/Resource/Account.php
+++ b/src/Resource/Account.php
@@ -39,6 +39,8 @@ class Account extends InstanceResource implements Deletable
     const FULL_NAME                = "fullName";
     const TENANT                   = "tenant";
     const PROVIDER_DATA			   = "providerData";
+    const ACCESS_TOKENS            = "accessTokens";
+    const REFRESH_TOKENS           = "refreshTokens";
 
     const PATH                     = "accounts";
 
@@ -154,6 +156,16 @@ class Account extends InstanceResource implements Deletable
     public function getDirectory(array $options = array())
     {
         return $this->getResourceProperty(self::DIRECTORY, Stormpath::DIRECTORY, $options);
+    }
+
+    public function getAccessTokens(array $options = array())
+    {
+        return $this->getResourceProperty(self::ACCESS_TOKENS, Stormpath::ACCESS_TOKEN_LIST, $options);
+    }
+
+    public function getRefreshTokens(array $options = array())
+    {
+        return $this->getResourceProperty(self::REFRESH_TOKENS, Stormpath::REFRESH_TOKEN_LIST, $options);
     }
 
     public function getEmailVerificationToken(array $options = array())

--- a/src/Resource/RefreshTokenList.php
+++ b/src/Resource/RefreshTokenList.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Stormpath\Resource;
+
+/*
+ * Copyright 2013 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use Stormpath\Stormpath;
+
+class RefreshTokenList extends AbstractCollectionResource
+{
+    function getItemClassName()
+    {
+        return Stormpath::REFRESH_TOKEN;
+    }
+
+}

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -21,6 +21,7 @@ namespace Stormpath;
 class Stormpath
 {
     const ACCESS_TOKEN                          = 'AccessToken';
+    const ACCESS_TOKEN_LIST                     = 'AccessTokenList';
     const ACCOUNT                               = 'Account';
     const ACCOUNT_CREATION_POLICY               = "AccountCreationPolicy";
     const ACCOUNT_LIST                          = 'AccountList';
@@ -59,6 +60,7 @@ class Stormpath
     const PROVIDER_ACCOUNT_RESULT               = 'ProviderAccountResult';
     const PROVIDER_DATA                         = 'ProviderData';
     const REFRESH_TOKEN                         = 'RefreshToken';
+    const REFRESH_TOKEN_LIST                    = 'RefreshTokenList';
     const TENANT                                = 'Tenant';
     const VERIFICATION_EMAIL                    = 'VerificationEmail';
 

--- a/tests/Oauth/PasswordRefreshGrantTest.php
+++ b/tests/Oauth/PasswordRefreshGrantTest.php
@@ -66,7 +66,7 @@ class PasswordRefreshGrantTest extends \Stormpath\Tests\TestCase
         $this->assertInstanceOf('Stormpath\Oauth\OauthGrantAuthenticationResult', self::$token);
         $this->assertInstanceOf('Stormpath\Resource\AccessToken', self::$token->getAccessToken());
         $this->assertCount(3, explode('.',self::$token->getAccessTokenString()));
-        $this->assertNull(self::$token->getRefreshToken());
+        $this->assertInstanceOf('Stormpath\Resource\RefreshToken', self::$token->getRefreshToken());
         $this->assertCount(3, explode('.',self::$token->getRefreshTokenString()));
         $this->assertcontains('/accessTokens/', self::$token->getAccessTokenHref());
         $this->assertEquals('Bearer', self::$token->getTokenType());

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -363,6 +363,18 @@ class AccountTest extends \Stormpath\Tests\TestCase {
         self::$account->addGroup(\Stormpath\Resource\Group::instantiate());
     }
 
+    public function testItCanGetAccessTokensOffAccount()
+    {
+        $tokens = self::$account->accessTokens;
+        $this->assertInstanceOf('Stormpath\Resource\AccessTokenList', $tokens);
+    }
+
+    public function testItCanGetRefreshTokensOffAccount()
+    {
+        $tokens = self::$account->refreshTokens;
+        $this->assertInstanceOf('Stormpath\Resource\RefreshTokenList', $tokens);
+    }
+
 
 
     public function testAddingCustomData()

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -363,20 +363,6 @@ class AccountTest extends \Stormpath\Tests\TestCase {
         self::$account->addGroup(\Stormpath\Resource\Group::instantiate());
     }
 
-    public function testItCanGetAccessTokensOffAccount()
-    {
-        $tokens = self::$account->accessTokens;
-        $this->assertInstanceOf('Stormpath\Resource\AccessTokenList', $tokens);
-    }
-
-    public function testItCanGetRefreshTokensOffAccount()
-    {
-        $tokens = self::$account->refreshTokens;
-        $this->assertInstanceOf('Stormpath\Resource\RefreshTokenList', $tokens);
-    }
-
-
-
     public function testAddingCustomData()
     {
         $cd = self::$account->customData;


### PR DESCRIPTION
 - Fixed a bug where the accessToken and refreshTokens were not accessible from the Account
 - We now show the refresh token object from OauthGrantAuthenticatorResult for all requests if enabled
 - Removed logging from the phpunit tests. If code coverage is needed, you should now use the flag on phpunit
 - Update Readme Documentation to reference the fixes and phpunit changes
 - Removed branch alias from composer.json file