### PR TITLE
Added SP_TOKEN to idsite for forgot password

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,21 @@ $forgotLink = $application->createIdSiteUrl(['path'=>'/#/forgot','callbackUri'=>
 header('Location:'.$forgotLink);  //or any other form of redirect to the $loginLink you want to use.
 ```
 
+##### Using SP_Token for password reset from workflow in ID Site
+
+We allow you to use the Workflow for password reset outside of the ID Site system, but enable you to use the password
+reset screens of the ID Site to do the password reset.  To allow for this, you need to pass in the `sp_token` parameter 
+that was provided in the email of the password reset.
+```php
+$application = \Stormpath\Resource\Application::get('{APPLICATION_ID}');
+$location = $application->createIdSiteUrl([
+    'path'=>'/#/reset', 
+    'sp_token'=>'{{SP_TOKEN}}',
+    'callbackUri'=>'{{CALLBACK_URI}}'
+]);
+header('Location:'.$forgotLink);  //or any other form of redirect to the $loginLink you want to use.
+```
+
 Again, with all these methods, You will want your application to link to an internal page where the JWT is created at 
 that time.  Without doing this, a user will only have 60 seconds to click on the link before the JWT expires.
 

--- a/src/Resource/Application.php
+++ b/src/Resource/Application.php
@@ -346,6 +346,10 @@ class Application extends InstanceResource implements Deletable
             'cb_uri'    => $options['callbackUri']
         );
 
+        if(isset($options['sp_token'])) {
+            $token['sp_token'] = $options['sp_token'];
+        }
+        
         if(isset($options['organizationNameKey'])) {
             $token['onk'] = $options['organizationNameKey'];
         }


### PR DESCRIPTION
Adds the ability to specify the sp_token as a param in the creation of the idsite url.  This is used for resetting the password.  You can take the sp_token from the email that is generated when using the workflow and use it in the ID Site password reset.

This looks like:

```
$location = $application->createIdSiteUrl([
    'path'=>'/#/reset', 
    'sp_token'=>'{{SP_TOKEN}}',
    'callbackUri'=>'{{CALLBACK_URI}}'
]);
```