### PR TITLE
Removed insecure salt fallback since openssl_random_pseudo_bytes

### DIFF
--- a/src/Authc/Api/ApiKeyEncryptionOptions.php
+++ b/src/Authc/Api/ApiKeyEncryptionOptions.php
@@ -45,9 +45,7 @@ class ApiKeyEncryptionOptions
                 $options[self::ENCRYPTION_KEY_ITERATIONS] :
                 self::DEFAULT_ENCRYPTION_KEY_ITERATIONS;
 
-            $salt = function_exists('openssl_random_pseudo_bytes') ?
-                openssl_random_pseudo_bytes(16) :
-                substr(md5(uniqid('', true)), -16);
+            $salt = openssl_random_pseudo_bytes(16);
 
             $this->options[self::ENCRYPTION_KEY_SALT] = ApiKeyEncryptionUtils::base64url_encode($salt);
         }


### PR DESCRIPTION
openssl_random_pseudo_bytes is available in php 5.3+ so we no longer need the fallback.