### PR TITLE
Updated Resource Error to include passing code to root Exception

### DIFF
--- a/src/Resource/ResourceError.php
+++ b/src/Resource/ResourceError.php
@@ -3,7 +3,7 @@
 namespace Stormpath\Resource;
 
 /*
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2013 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class ResourceError extends \RuntimeException
 
     public function __construct(Error $error)
     {
-        parent::__construct(($error->getMessage()) ? $error->getMessage() : '');
+        parent::__construct(($error->getMessage()) ? $error->getMessage() : '', $error->getCode());
         $this->error = $error;
     }
 

--- a/src/Resource/ResourceError.php
+++ b/src/Resource/ResourceError.php
@@ -3,7 +3,7 @@
 namespace Stormpath\Resource;
 
 /*
- * Copyright 2013 Stormpath, Inc.
+ * Copyright 2016 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Currently, the Resource Error does not pass the code to the parent exception class.  This makes it not possible to pull the code in.