### PR TITLE
update facebook provider to work with code and access_token

### DIFF
--- a/src/Provider/FacebookProviderAccountRequest.php
+++ b/src/Provider/FacebookProviderAccountRequest.php
@@ -27,6 +27,7 @@ use Stormpath\Stormpath;
 class FacebookProviderAccountRequest implements ProviderAccountRequest
 {
     const ACCESS_TOKEN  = 'accessToken';
+    const CODE          = 'code';
 
     private $options;
 
@@ -48,13 +49,17 @@ class FacebookProviderAccountRequest implements ProviderAccountRequest
 
         $providerData->providerId = FacebookProviderData::PROVIDER_ID;
 
-        if (isset($this->options[self::ACCESS_TOKEN]))
+        if (isset($this->options[self::CODE]))
+        {
+            $providerData->code = $this->options[self::CODE];
+        }
+        else if (isset($this->options[self::ACCESS_TOKEN]))
         {
             $providerData->accessToken = $this->options[self::ACCESS_TOKEN];
         }
         else
         {
-            throw new \InvalidArgumentException('accessToken must be set for FacebookProviderAccountRequest');
+            throw new \InvalidArgumentException('Either code or accessToken must be set for FacebookProviderAccountRequest');
         }
 
         return $providerData;

--- a/src/Resource/FacebookProviderData.php
+++ b/src/Resource/FacebookProviderData.php
@@ -22,7 +22,19 @@ class FacebookProviderData extends ProviderData
 {
     const PROVIDER_ID   = 'facebook';
 
+    const CODE          = 'code';
     const ACCESS_TOKEN  = 'accessToken';
+    const REFRESH_TOKEN = 'refreshToken';
+
+    public function getCode()
+    {
+        return $this->getProperty(self::CODE);
+    }
+
+    public function setCode($code)
+    {
+        $this->setProperty(self::CODE, $code);
+    }
 
     public function getAccessToken()
     {
@@ -32,6 +44,16 @@ class FacebookProviderData extends ProviderData
     public function setAccessToken($accessToken)
     {
         $this->setProperty(self::ACCESS_TOKEN, $accessToken);
+    }
+
+    public function getRefreshToken()
+    {
+        return $this->getProperty(self::REFRESH_TOKEN);
+    }
+
+    public function setRefreshToken($refreshToken)
+    {
+        $this->setProperty(self::REFRESH_TOKEN, $refreshToken);
     }
 
 }

--- a/src/Resource/GithubProviderData.php
+++ b/src/Resource/GithubProviderData.php
@@ -23,6 +23,7 @@ class GithubProviderData extends ProviderData
     const PROVIDER_ID   = 'github';
 
     const ACCESS_TOKEN  = 'accessToken';
+    const CODE          = 'code';
 
     public function getAccessToken()
     {
@@ -32,6 +33,16 @@ class GithubProviderData extends ProviderData
     public function setAccessToken($accessToken)
     {
         $this->setProperty(self::ACCESS_TOKEN, $accessToken);
+    }
+
+    public function getCode()
+    {
+        return $this->getProperty(self::CODE);
+    }
+
+    public function setCode($code)
+    {
+        $this->setProperty(self::CODE, $code);
     }
 
 }

--- a/src/Resource/LinkedInProvider.php
+++ b/src/Resource/LinkedInProvider.php
@@ -27,6 +27,7 @@ class LinkedInProvider extends Provider
     const CLIENT_ID             = 'clientId';
     const CLIENT_SECRET         = 'clientSecret';
     const LINKEDIN_PROVIDER_ID  = 'linkedin';
+    const REDIRECT_URI          = 'redirectUri';
 
     public static function get($href, array $options = array())
     {
@@ -69,4 +70,13 @@ class LinkedInProvider extends Provider
         $this->setProperty(self::CLIENT_SECRET, $clientSecret);
     }
 
+    public function getRedirectUri()
+    {
+        return $this->getProperty(self::REDIRECT_URI);
+    }
+
+    public function setRedirectUri($redirectUri)
+    {
+        $this->setProperty(self::REDIRECT_URI, $redirectUri);
+    }
 }

--- a/src/Resource/LinkedInProviderData.php
+++ b/src/Resource/LinkedInProviderData.php
@@ -23,6 +23,7 @@ class LinkedInProviderData extends ProviderData
     const PROVIDER_ID   = 'linkedin';
 
     const ACCESS_TOKEN  = 'accessToken';
+    const CODE          = 'code';
 
     public function getAccessToken()
     {
@@ -32,6 +33,16 @@ class LinkedInProviderData extends ProviderData
     public function setAccessToken($accessToken)
     {
         $this->setProperty(self::ACCESS_TOKEN, $accessToken);
+    }
+
+    public function getCode()
+    {
+        return $this->getProperty(self::CODE);
+    }
+
+    public function setCode($code)
+    {
+        $this->setProperty(self::CODE, $code);
     }
 
 }


### PR DESCRIPTION
Pull request description
------------------------
This adds in code AND access_token to the FacebookAccountRequest object.

Fixes #142 