### PR TITLE
Fix cache key for resources when expands using the Expand object (WIP)

### DIFF
--- a/src/Cache/PSR6CacheKeyTrait.php
+++ b/src/Cache/PSR6CacheKeyTrait.php
@@ -8,6 +8,9 @@ trait PSR6CacheKeyTrait
     {
         if (is_array($query)) {
             ksort($query);
+            foreach ($query as $key => $value) {
+                $query[$key] = (string) $value;
+            }
             $query = http_build_query($query);
         }
         $key = $href.'?'.$query;


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [x] My changes contain only a single type of change (one bugfix or feature). 
- [x] I have read and understood CONTRIBUTING guide

Code Coverage:
(not applicable for non-code fixes of course)
- [ ] My pull request has tests that cover 100% of the updated code. (phpunit --coverage-html code-coverage)
- [ ] My pull request does not remove any tests that are still needed.

Commits:
- [x] My commits are logical, easily readable, with concise comments.
- [x] My code follows PSR standards of coding style

Licensing:
- [x] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.
- [x] Any new files contain the copyright header directly after the opening <?php line

Branching:
- [x] My submission is based on dev branch
- [x] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [x] The name of the branch I want to merge upstream is not 'master'.
- [x] My branch name follows the pattern *feature/some-new-shiny-feature* (for new features).
- [x] My branch name follows the pattern *bugfix/some-bugfix* (for bugfixes).

Continuous integration:
- [ ] Once I will submit this pull request, I will wait for Travis-CI report (normally a couple of minutes) and fix any issues I might have introduced.



Pull request description
------------------------
When building the cache key, the `http_build_query` didn't handle values of `Stormpath\Resource\Expansion` type. So that is now done manually, before invoking `http_build_query`.

I couldn't get the tests to work, so I have left those unchecked above, hence "WIP" in the subject . Could someone else verify this PR?