### PR TITLE
Adds the ability to work with Password Policy of a Directory

### DIFF
--- a/src/DataStore/DefaultDataStore.php
+++ b/src/DataStore/DefaultDataStore.php
@@ -353,13 +353,14 @@ class DefaultDataStore extends Cacheable implements InternalDataStore
             $property = $resource->getProperty($name);
 
             $nameIsCustomData = $name == CustomData::CUSTOMDATA_PROP_NAME;
+            $nameIsDefaultModel = $name == 'defaultModel';
 
             if ($property instanceof \Stormpath\Resource\CustomData)
             {
                 $property = $this->toStdClass($property, true);
             }
 
-            else if ($property instanceof \stdClass && $customData === false && !$nameIsCustomData)
+            else if ($property instanceof \stdClass && $customData === false && !$nameIsCustomData && !$nameIsDefaultModel)
             {
                 $property = $this->toSimpleReference($name, $property);
             }

--- a/src/Directory/PasswordPolicy.php
+++ b/src/Directory/PasswordPolicy.php
@@ -29,6 +29,7 @@ class PasswordPolicy extends InstanceResource
     const RESET_EMAIL_STATUS            = "resetEmailStatus";
     const RESET_EMAIL_TEMPLATES         = "resetEmailTemplates";
     const RESET_SUCCESS_EMAIL_STATUS    = "resetSuccessEmailStatus";
+    const RESET_SUCCESS_EMAIL_TEMPLATES = "resetSuccessEmailTemplates";
 
     const PATH                          = 'passwordPolicies';
 
@@ -76,4 +77,11 @@ class PasswordPolicy extends InstanceResource
     {
         return $this->getResourceProperty(self::RESET_EMAIL_TEMPLATES, Stormpath::MODELED_EMAIL_TEMPLATE_LIST, $options);
     }
+
+    public function getResetSuccessEmailTemplates(array $options = [])
+    {
+        return $this->getResourceProperty(self::RESET_SUCCESS_EMAIL_TEMPLATES, Stormpath::UNMODELED_EMAIL_TEMPLATE_LIST, $options);
+    }
+
+
 }

--- a/src/Directory/PasswordPolicy.php
+++ b/src/Directory/PasswordPolicy.php
@@ -27,6 +27,7 @@ class PasswordPolicy extends InstanceResource
     const RESET_TOKEN_TTL               = "resetTokenTtl";
     const PASSWORD_STRENGTH             = "strength";
     const RESET_EMAIL_STATUS            = "resetEmailStatus";
+    const RESET_EMAIL_TEMPLATES         = "resetEmailTemplates";
     const RESET_SUCCESS_EMAIL_STATUS    = "resetSuccessEmailStatus";
 
     const PATH                          = 'passwordPolicies';
@@ -69,5 +70,10 @@ class PasswordPolicy extends InstanceResource
     public function getStrength(array $options = [])
     {
         return $this->getResourceProperty(self::PASSWORD_STRENGTH, Stormpath::PASSWORD_STRENGTH, $options);
+    }
+
+    public function getResetEmailTemplates(array $options = [])
+    {
+        return $this->getResourceProperty(self::RESET_EMAIL_TEMPLATES, Stormpath::MODELED_EMAIL_TEMPLATE_LIST, $options);
     }
 }

--- a/src/Directory/PasswordPolicy.php
+++ b/src/Directory/PasswordPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Directory;
+
+use Stormpath\Client;
+use Stormpath\Resource\InstanceResource;
+use Stormpath\Stormpath;
+
+class PasswordPolicy extends InstanceResource
+{
+    const RESET_TOKEN_TTL               = "resetTokenTtl";
+    const PASSWORD_STRENGTH             = "strength";
+    const RESET_EMAIL_STATUS            = "resetEmailStatus";
+    const RESET_SUCCESS_EMAIL_STATUS    = "resetSuccessEmailStatus";
+
+    const PATH                          = 'passwordPolicies';
+
+    public static function get($href, array $options = [])
+    {
+        return Client::get($href, Stormpath::PASSWORD_POLICY, self::PATH, $options);
+    }
+
+    public function getResetTokenTtl()
+    {
+        return $this->getProperty(self::RESET_TOKEN_TTL);
+    }
+
+    public function setResetTokenTtl($ttl)
+    {
+        $this->setProperty(self::RESET_TOKEN_TTL, $ttl);
+    }
+
+    public function getResetEmailStatus()
+    {
+        return $this->getProperty(self::RESET_EMAIL_STATUS);
+    }
+
+    public function setResetEmailStatus($ttl)
+    {
+        $this->setProperty(self::RESET_EMAIL_STATUS, $ttl);
+    }
+
+    public function getResetSuccessEmailStatus()
+    {
+        return $this->getProperty(self::RESET_EMAIL_STATUS);
+    }
+
+    public function setResetSuccessEmailStatus($ttl)
+    {
+        $this->setProperty(self::RESET_EMAIL_STATUS, $ttl);
+    }
+
+    public function getStrength(array $options = [])
+    {
+        return $this->getResourceProperty(self::PASSWORD_STRENGTH, Stormpath::PASSWORD_STRENGTH, $options);
+    }
+}

--- a/src/Directory/PasswordStrength.php
+++ b/src/Directory/PasswordStrength.php
@@ -1,0 +1,237 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Directory;
+
+use Stormpath\Client;
+use Stormpath\Resource\InstanceResource;
+use Stormpath\Stormpath;
+
+class PasswordStrength extends InstanceResource
+{
+    const HREF              = "href";
+    const MIN_LENGTH        = "minLength";
+    const MAX_LENGTH        = "maxLength";
+    const MIN_NUMERIC       = "minNumeric";
+    const MIN_SYMBOL        = "minSymbol";
+    const MIN_DIACRITIC     = "minDiacritic";
+    const PREVENT_REUSE     = "preventReuse";
+    const MIN_LOWER_CASE    = "minLowerCase";
+    const MIN_UPPER_CASE    = "minUpperCase";
+
+    const PATH              = "strength";
+
+
+    public static function get($href, array $options = [])
+    {
+        return Client::get($href, Stormpath::PASSWORD_STRENGTH, self::PATH, $options);
+    }
+    /**
+     * Gets the href property
+     *
+     * @return string
+     */
+    public function getHref()
+    {
+        return $this->getProperty(self::HREF);
+    }
+    /**
+     * Gets the minLength property
+     *
+     * @return integer
+     */
+    public function getMinLength()
+    {
+        return $this->getProperty(self::MIN_LENGTH);
+    }
+
+    /**
+     * Sets the minLength property
+     *
+     * @param integer $minLength The minLength of the object
+     * @return self
+     */
+    public function setMinLength($minLength)
+    {
+        $this->setProperty(self::MIN_LENGTH, $minLength);
+
+        return $this;
+    }
+
+
+    /**
+     * Gets the maxLength property
+     *
+     * @return integer
+     */
+    public function getMaxLength()
+    {
+        return $this->getProperty(self::MAX_LENGTH);
+    }
+    
+    /**
+     * Sets the maxLength property
+     *
+     * @param integer $maxLength The maxLength of the object
+     * @return self
+     */
+    public function setMaxLength($maxLength)
+    {
+        $this->setProperty(self::MAX_LENGTH, $maxLength);
+        
+        return $this; 
+    }
+
+    /**
+     * Gets the minLowerCase property
+     *
+     * @return integer
+     */
+    public function getMinLowerCase()
+    {
+        return $this->getProperty(self::MIN_LOWER_CASE);
+    }
+    
+    /**
+     * Sets the minLowerCase property
+     *
+     * @param integer $minLowerCase The minLowerCase of the object
+     * @return self
+     */
+    public function setMinLowerCase($minLowerCase)
+    {
+        $this->setProperty(self::MIN_LOWER_CASE, $minLowerCase);
+        
+        return $this; 
+    }
+
+    /**
+     * Gets the minUpperCase property
+     *
+     * @return integer
+     */
+    public function getMinUpperCase()
+    {
+        return $this->getProperty(self::MIN_UPPER_CASE);
+    }
+
+    /**
+     * Sets the minUpperCase property
+     *
+     * @param integer $minUpperCase The minUpperCase of the object
+     * @return self
+     */
+    public function setMinUpperCase($minUpperCase)
+    {
+        $this->setProperty(self::MIN_UPPER_CASE, $minUpperCase);
+
+        return $this;
+    }
+
+    /**
+     * Gets the minNumeric property
+     *
+     * @return integer
+     */
+    public function getMinNumeric()
+    {
+        return $this->getProperty(self::MIN_NUMERIC);
+    }
+
+    /**
+     * Sets the minNumeric property
+     *
+     * @param integer $minNumeric The minNumeric of the object
+     * @return self
+     */
+    public function setMinNumeric($minNumeric)
+    {
+        $this->setProperty(self::MIN_NUMERIC, $minNumeric);
+
+        return $this;
+    }
+
+    /**
+     * Gets the minSymbol property
+     *
+     * @return integer
+     */
+    public function getMinSymbol()
+    {
+        return $this->getProperty(self::MIN_SYMBOL);
+    }
+
+    /**
+     * Sets the minSymbol property
+     *
+     * @param integer $minSymbol The minSymbol of the object
+     * @return self
+     */
+    public function setMinSymbol($minSymbol)
+    {
+        $this->setProperty(self::MIN_SYMBOL, $minSymbol);
+
+        return $this;
+    }
+
+    /**
+     * Gets the minDiacritic property
+     *
+     * @return integer
+     */
+    public function getMinDiacritic()
+    {
+        return $this->getProperty(self::MIN_DIACRITIC);
+    }
+
+    /**
+     * Sets the minDiacritic property
+     *
+     * @param integer $minDiacritic The minDiacritic of the object
+     * @return self
+     */
+    public function setMinDiacritic($minDiacritic)
+    {
+        $this->setProperty(self::MIN_DIACRITIC, $minDiacritic);
+
+        return $this;
+    }
+
+    /**
+     * Gets the preventReuse property
+     *
+     * @return integer
+     */
+    public function getPreventReuse()
+    {
+        return $this->getProperty(self::PREVENT_REUSE);
+    }
+
+    /**
+     * Sets the preventReuse property
+     *
+     * @param integer $preventReuse The preventReuse of the object
+     * @return self
+     */
+    public function setPreventReuse($preventReuse)
+    {
+        $this->setProperty(self::PREVENT_REUSE, $preventReuse);
+
+        return $this;
+    }
+
+}

--- a/src/Mail/EmailTemplate.php
+++ b/src/Mail/EmailTemplate.php
@@ -1,0 +1,228 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Stormpath\Mail;
+
+use Stormpath\Resource\InstanceResource;
+
+abstract class EmailTemplate extends InstanceResource
+{
+    const NAME                  = "name";
+    const SUBJECT               = "subject";
+    const FROM_NAME             = "fromName";
+    const TEXT_BODY             = "textBody";
+    const HTML_BODY             = "htmlBody";
+    const MIME_TYPE             = "mimeType";
+    const DESCRIPTION           = "description";
+    const FROM_EMAIL_ADDRESS    = "fromEmailAddress";
+
+    const PATH = "emailTemplates";
+
+    /**
+     * Gets the href property
+     *
+     * @return
+     */
+    public function getHref()
+    {
+        return $this->getProperty(self::HREF);
+    }
+
+    /**
+     * Gets the name property
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->getProperty(self::NAME);
+    }
+
+    /**
+     * Sets the name property
+     *
+     * @param string $name The name of the object
+     * @return self
+     */
+    public function setName($name)
+    {
+        $this->setProperty(self::NAME, $name);
+
+        return $this;
+    }
+
+    /**
+     * Gets the description property
+     *
+     * @return string
+     */
+    public function getDescription()
+    {
+        return $this->getProperty(self::DESCRIPTION);
+    }
+
+    /**
+     * Sets the description property
+     *
+     * @param string $description The description of the object
+     * @return self
+     */
+    public function setDescription($description)
+    {
+        $this->setProperty(self::DESCRIPTION, $description);
+
+        return $this;
+    }
+
+    /**
+     * Gets the fromName property
+     *
+     * @return string
+     */
+    public function getFromName()
+    {
+        return $this->getProperty(self::FROM_NAME);
+    }
+
+    /**
+     * Sets the fromName property
+     *
+     * @param string $fromName The fromName of the object
+     * @return self
+     */
+    public function setFromName($fromName)
+    {
+        $this->setProperty(self::FROM_NAME, $fromName);
+
+        return $this;
+    }
+
+    /**
+     * Gets the fromEmailAddress property
+     *
+     * @return string
+     */
+    public function getFromEmailAddress()
+    {
+        return $this->getProperty(self::FROM_EMAIL_ADDRESS);
+    }
+
+    /**
+     * Sets the fromEmailAddress property
+     *
+     * @param string $fromEmailAddress The fromEmailAddress of the object
+     * @return self
+     */
+    public function setFromEmailAddress($fromEmailAddress)
+    {
+        $this->setProperty(self::FROM_EMAIL_ADDRESS, $fromEmailAddress);
+
+        return $this;
+    }
+
+    /**
+     * Gets the subject property
+     *
+     * @return string
+     */
+    public function getSubject()
+    {
+        return $this->getProperty(self::SUBJECT);
+    }
+
+    /**
+     * Sets the subject property
+     *
+     * @param string $subject The subject of the object
+     * @return self
+     */
+    public function setSubject($subject)
+    {
+        $this->setProperty(self::SUBJECT, $subject);
+
+        return $this;
+    }
+
+    /**
+     * Gets the textBody property
+     *
+     * @return string
+     */
+    public function getTextBody()
+    {
+        return $this->getProperty(self::TEXT_BODY);
+    }
+
+    /**
+     * Sets the textBody property
+     *
+     * @param string $textBody The textBody of the object
+     * @return self
+     */
+    public function setTextBody($textBody)
+    {
+        $this->setProperty(self::TEXT_BODY, $textBody);
+
+        return $this;
+    }
+
+    /**
+     * Gets the htmlBody property
+     *
+     * @return string
+     */
+    public function getHtmlBody()
+    {
+        return $this->getProperty(self::HTML_BODY);
+    }
+
+    /**
+     * Sets the htmlBody property
+     *
+     * @param string $htmlBody The htmlBody of the object
+     * @return self
+     */
+    public function setHtmlBody($htmlBody)
+    {
+        $this->setProperty(self::HTML_BODY, $htmlBody);
+
+        return $this;
+    }
+
+    /**
+     * Gets the mimeType property
+     *
+     * @return string
+     */
+    public function getMimeType()
+    {
+        return $this->getProperty(self::MIME_TYPE);
+    }
+
+    /**
+     * Sets the mimeType property
+     *
+     * @param string $mimeType The mimeType of the object
+     * @return self
+     */
+    public function setMimeType($mimeType)
+    {
+        $this->setProperty(self::MIME_TYPE, $mimeType);
+
+        return $this;
+    }
+
+}

--- a/src/Mail/EmailTemplate.php
+++ b/src/Mail/EmailTemplate.php
@@ -38,7 +38,7 @@ abstract class EmailTemplate extends InstanceResource
      */
     public function getHref()
     {
-        return $this->getProperty(self::HREF);
+        return $this->getProperty(self::HREF_PROP_NAME);
     }
 
     /**

--- a/src/Mail/ModeledEmailTemplate.php
+++ b/src/Mail/ModeledEmailTemplate.php
@@ -1,0 +1,104 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Mail;
+
+class ModeledEmailTemplate extends EmailTemplate
+{
+    const DEFAULT_MODEL = 'defaultModel';
+    const LINK_BASE_URL = 'linkBaseUrl';
+
+    /**
+     * Gets the defaultModel property
+     *
+     * @return array
+     */
+    public function getDefaultModel()
+    {
+        return $this->getProperty(self::DEFAULT_MODEL);
+    }
+
+    /**
+     * Sets the defaultModel property
+     *
+     * @param array $defaultModel The defaultModel of the object
+     * @return self
+     */
+    public function setDefaultModel($defaultModel)
+    {
+        $this->setProperty(self::DEFAULT_MODEL, $defaultModel);
+
+        return $this;
+    }
+
+    /**
+     * Return the clickable URL that the user will receive inside the email.
+     * This is just a convenience method for getting the `linkBaseUrl` out of
+     * the `default model` array.
+     *
+     * @return null|string the URL the user will be taken to once they click on the URL received in the email.
+     */
+    public function getLinkBaseUrl()
+    {
+        $defaultModel = $this->getDefaultModel();
+
+        if(empty($defaultModel) || !key_exists(self::LINK_BASE_URL, $defaultModel)) {
+            return null;
+        }
+
+        return $defaultModel[self::LINK_BASE_URL];
+    }
+
+    /**
+     * Convenience method to specify the clickable url that the user will receive
+     * inside the email. For Example, in the reset password workflow, this url
+     * should point to the form where the user can insert their new password.
+     *
+     * @param string $linkBaseUrl the URL the user will be taken to once they click on the URL received in the email.
+     * @return $this
+     */
+    public function setLinkBaseUrl($linkBaseUrl)
+    {
+        $defaultModel = $this->getDefaultModel();
+
+        $defaultModel[self::LINK_BASE_URL] = $linkBaseUrl;
+
+        $this->setDefaultModel($defaultModel);
+
+        return $this;
+    }
+
+    /**
+     * Save the model, Ultimately, this will call the parent save, but we want to
+     * make sure the `linkBaseUrl` is set and not null first. This is required
+     * by Stormpath to not be null when saving.
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function save()
+    {
+        if(null === $this->getLinkBaseUrl()) {
+            throw new \InvalidArgumentException('The defaultModel must contain the "linkBaseUrl" reserved property');
+        }
+
+        return parent::save();
+    }
+
+
+
+
+}

--- a/src/Mail/ModeledEmailTemplate.php
+++ b/src/Mail/ModeledEmailTemplate.php
@@ -54,7 +54,7 @@ class ModeledEmailTemplate extends EmailTemplate
      */
     public function getLinkBaseUrl()
     {
-        $defaultModel = $this->getDefaultModel();
+        $defaultModel = (array)$this->getDefaultModel();
 
         if(empty($defaultModel) || !key_exists(self::LINK_BASE_URL, $defaultModel)) {
             return null;
@@ -95,10 +95,9 @@ class ModeledEmailTemplate extends EmailTemplate
             throw new \InvalidArgumentException('The defaultModel must contain the "linkBaseUrl" reserved property');
         }
 
-        return parent::save();
+        parent::save();
+
+        return;
     }
-
-
-
 
 }

--- a/src/Mail/ModeledEmailTemplateList.php
+++ b/src/Mail/ModeledEmailTemplateList.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Mail;
+
+use Stormpath\Resource\AbstractCollectionResource;
+use Stormpath\Stormpath;
+
+class ModeledEmailTemplateList extends AbstractCollectionResource
+{
+
+    function getItemClassName()
+    {
+        return Stormpath::MODELED_EMAIL_TEMPLATE;
+    }
+}

--- a/src/Mail/UnmodeledEmailTemplate.php
+++ b/src/Mail/UnmodeledEmailTemplate.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Mail;
+
+class UnmodeledEmailTemplate extends EmailTemplate {}

--- a/src/Mail/UnmodeledEmailTemplateList.php
+++ b/src/Mail/UnmodeledEmailTemplateList.php
@@ -1,0 +1,30 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Mail;
+
+use Stormpath\Resource\AbstractCollectionResource;
+use Stormpath\Stormpath;
+
+class UnmodeledEmailTemplateList extends AbstractCollectionResource
+{
+
+    function getItemClassName()
+    {
+        return Stormpath::UNMODELED_EMAIL_TEMPLATE;
+    }
+}

--- a/src/Resource/Directory.php
+++ b/src/Resource/Directory.php
@@ -31,6 +31,7 @@ class Directory extends AccountStore implements Deletable
     const TENANT      = "tenant";
     const PROVIDER    = "provider";
     const CUSTOM_DATA = "customData";
+    const PASSWORD_POLICY = "passwordPolicy";
     const ACCOUNT_CREATION_POLICY = "accountCreationPolicy";
 
     const PATH        = "directories";
@@ -154,6 +155,11 @@ class Directory extends AccountStore implements Deletable
     public function getProvider(array $options = array())
     {
         return $this->getResourceProperty(self::PROVIDER, Stormpath::PROVIDER, $options);
+    }
+
+    public function getPasswordPolicy(array $options = [])
+    {
+        return $this->getResourceProperty(self::PASSWORD_POLICY, Stormpath::PASSWORD_POLICY, $options);
     }
 
     public function delete() {

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -57,6 +57,7 @@ class Stormpath
     const ORGANIZATION                                  = 'Organization';
     const ORGANIZATION_LIST                             = 'OrganizationList';
     const PASSWORD_RESET_TOKEN                          = 'PasswordResetToken';
+    const PASSWORD_POLICY                               = 'Stormpath\Directory\PasswordPolicy';
     const PROVIDER                                      = 'Provider';
     const PROVIDER_ACCOUNT_ACCESS                       = 'ProviderAccountAccess';
     const PROVIDER_ACCOUNT_RESULT                       = 'ProviderAccountResult';

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -56,8 +56,9 @@ class Stormpath
     const OAUTH_POLICY                                  = 'OauthPolicy';
     const ORGANIZATION                                  = 'Organization';
     const ORGANIZATION_LIST                             = 'OrganizationList';
-    const PASSWORD_RESET_TOKEN                          = 'PasswordResetToken';
     const PASSWORD_POLICY                               = 'Stormpath\Directory\PasswordPolicy';
+    const PASSWORD_RESET_TOKEN                          = 'PasswordResetToken';
+    const PASSWORD_STRENGTH                             = 'Stormpath\Directory\PasswordStrength';
     const PROVIDER                                      = 'Provider';
     const PROVIDER_ACCOUNT_ACCESS                       = 'ProviderAccountAccess';
     const PROVIDER_ACCOUNT_RESULT                       = 'ProviderAccountResult';

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -65,6 +65,8 @@ class Stormpath
     const PROVIDER_DATA                                 = 'ProviderData';
     const REFRESH_TOKEN                                 = 'RefreshToken';
     const REFRESH_TOKEN_LIST                            = 'RefreshTokenList';
+    const MODELED_EMAIL_TEMPLATE                        = 'Stormpath\Mail\ModeledEmailTemplate';
+    const MODELED_EMAIL_TEMPLATE_LIST                   = 'Stormpath\Mail\ModeledEmailTemplateList';
     const SAML_PROVIDER                                 = 'SamlProvider';
     const SAML_PROVIDER_DATA                            = 'SamlProviderData';
     const TENANT                                        = 'Tenant';
@@ -88,6 +90,9 @@ class Stormpath
     const SAUTHC1_AUTHENTICATION_SCHEME                 = 'SAuthc1';
     const BASIC_AUTHENTICATION_SCHEME                   = 'Basic';
 
+    const MIME_PLAIN_TEXT                               = 'text/plain';
+    const MIME_HTML                                     = 'text/html';
+
     public static $Statuses             = array(self::DISABLED => self::DISABLED,
                                             self::ENABLED => self::ENABLED);
 
@@ -98,5 +103,9 @@ class Stormpath
 
     public static $Sorts                = array(self::ASCENDING => self::ASCENDING,
                                             self::DESCENDING => self::DESCENDING);
+
+    public static $MimeTypes            = array(
+                                            self::MIME_PLAIN_TEXT => self::MIME_PLAIN_TEXT,
+                                            self::MIME_HTML => self::MIME_HTML);
 
 }

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -70,6 +70,8 @@ class Stormpath
     const SAML_PROVIDER                                 = 'SamlProvider';
     const SAML_PROVIDER_DATA                            = 'SamlProviderData';
     const TENANT                                        = 'Tenant';
+    const UNMODELED_EMAIL_TEMPLATE                      = 'Stormpath\Mail\UnmodeledEmailTemplate';
+    const UNMODELED_EMAIL_TEMPLATE_LIST                 = 'Stormpath\Mail\UnmodeledEmailTemplateList';
     const VERIFICATION_EMAIL                            = 'VerificationEmail';
     const X509_SIGNING_CERT                             = 'X509SigningCert';
 

--- a/tests/Directory/PasswordPolicyTest.php
+++ b/tests/Directory/PasswordPolicyTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Tests\Directory;
+
+use Stormpath\Stormpath;
+
+class PasswordPolicyTest extends \Stormpath\Tests\TestCase
+{
+    private static $directory;
+    private static $passwordPolicy;
+    private static $inited;
+
+    protected static function init()
+    {
+        self::$directory = \Stormpath\Resource\Directory::instantiate(array('name' => makeUniqueName('PasswordPolicyTest'), 'description' => 'Main Directory description'));
+        self::createResource(\Stormpath\Resource\Directory::PATH, self::$directory);
+        self::$passwordPolicy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        self::$inited = true;
+    }
+
+    public function setUp()
+    {
+        if (!self::$inited)
+        {
+            self::init();
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (self::$directory)
+        {
+            self::$directory->delete();
+        }
+        parent::tearDownAfterClass();
+    }
+    
+    /** @test */
+    public function can_get_password_policy_based_on_href()
+    {
+        $passwordPolicy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+
+        $this->assertInstanceOf(\Stormpath\Directory\PasswordPolicy::class, $passwordPolicy);
+    }
+
+    /** @test */
+    public function reset_token_ttl_accessible()
+    {
+        $this->assertEquals(24, self::$passwordPolicy->getResetTokenTtl());
+        $this->assertEquals(24, self::$passwordPolicy->resetTokenTtl);
+    }
+
+    /** @test */
+    public function reset_token_ttl_savable()
+    {
+        self::$passwordPolicy->resetTokenTtl = 10;
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(10, $policy->resetTokenTtl);
+
+        self::$passwordPolicy->setResetTokenTtl(24);
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(24, $policy->resetTokenTtl);
+
+    }
+
+    /** @test */
+    public function reset_email_status_accessible()
+    {
+        $this->assertEquals(Stormpath::ENABLED, self::$passwordPolicy->getResetEmailStatus());
+        $this->assertEquals(Stormpath::ENABLED, self::$passwordPolicy->resetEmailStatus);
+    }
+
+    /** @test */
+    public function reset_email_status_savable()
+    {
+        self::$passwordPolicy->resetEmailStatus = Stormpath::DISABLED;
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(Stormpath::DISABLED, $policy->resetEmailStatus);
+
+        self::$passwordPolicy->setResetEmailStatus(Stormpath::ENABLED);
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(Stormpath::ENABLED, $policy->resetEmailStatus);
+
+    }
+
+    /** @test */
+    public function reset_success_email_status_accessible()
+    {
+        $this->assertEquals(Stormpath::ENABLED, self::$passwordPolicy->getResetSuccessEmailStatus());
+        $this->assertEquals(Stormpath::ENABLED, self::$passwordPolicy->resetSuccessEmailStatus);
+    }
+
+    /** @test */
+    public function reset_success_email_status_savable()
+    {
+        self::$passwordPolicy->resetSuccessEmailStatus = Stormpath::DISABLED;
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(Stormpath::DISABLED, $policy->resetSuccessEmailStatus);
+
+        self::$passwordPolicy->setResetSuccessEmailStatus(Stormpath::ENABLED);
+        self::$passwordPolicy->save();
+        $policy = \Stormpath\Directory\PasswordPolicy::get(self::$directory->passwordPolicy->href);
+        $this->assertEquals(Stormpath::ENABLED, $policy->resetSuccessEmailStatus);
+
+    }
+    
+    /** @test */
+    public function accessor_for_strength_returns_strength_resource()
+    {
+        $strength = self::$passwordPolicy->getStrength();
+        $this->assertInstanceOf(\Stormpath\Directory\PasswordStrength::class, $strength);
+    }
+
+
+
+    
+    
+    
+}

--- a/tests/Directory/PasswordPolicyTest.php
+++ b/tests/Directory/PasswordPolicyTest.php
@@ -131,6 +131,13 @@ class PasswordPolicyTest extends \Stormpath\Tests\TestCase
         $strength = self::$passwordPolicy->getStrength();
         $this->assertInstanceOf(\Stormpath\Directory\PasswordStrength::class, $strength);
     }
+    
+    /** @test */
+    public function accessor_for_reset_email_templates_returns_resource()
+    {
+        $resetEmailTemplates = self::$passwordPolicy->getResetEmailTemplates();
+        $this->assertInstanceOf(\Stormpath\Resource\AbstractCollectionResource::class, $resetEmailTemplates);
+    }
 
 
 

--- a/tests/Directory/PasswordPolicyTest.php
+++ b/tests/Directory/PasswordPolicyTest.php
@@ -133,11 +133,19 @@ class PasswordPolicyTest extends \Stormpath\Tests\TestCase
     }
     
     /** @test */
-    public function accessor_for_reset_email_templates_returns_resource()
+    public function accessor_for_reset_email_templates_returns_modeled_email_template_list_resource()
     {
         $resetEmailTemplates = self::$passwordPolicy->getResetEmailTemplates();
-        $this->assertInstanceOf(\Stormpath\Resource\AbstractCollectionResource::class, $resetEmailTemplates);
+        $this->assertInstanceOf(\Stormpath\Mail\ModeledEmailTemplateList::class, $resetEmailTemplates);
     }
+
+    /** @test */
+    public function accessor_for_reset_success_email_templates_returns_unmodeled_email_template_list_resource()
+    {
+        $resetSuccessEmailTemplates = self::$passwordPolicy->getResetSuccessEmailTemplates();
+        $this->assertInstanceOf(\Stormpath\Mail\UnmodeledEmailTemplateList::class, $resetSuccessEmailTemplates);
+    }
+
 
 
 

--- a/tests/Directory/PasswordStrengthTest.php
+++ b/tests/Directory/PasswordStrengthTest.php
@@ -1,0 +1,249 @@
+<?php
+
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Stormpath\Tests\Directory;
+
+use Stormpath\Stormpath;
+
+class PasswordStrengthTest extends \Stormpath\Tests\TestCase
+{
+    private static $directory;
+    private static $passwordStrength;
+    private static $inited;
+
+    protected static function init()
+    {
+        self::$directory = \Stormpath\Resource\Directory::instantiate(array('name' => makeUniqueName('PasswordStrengthTest'), 'description' => 'Main Directory description'));
+        self::createResource(\Stormpath\Resource\Directory::PATH, self::$directory);
+        self::$passwordStrength = self::$directory->passwordPolicy->strength;
+        self::$inited = true;
+    }
+
+    public function setUp()
+    {
+        if (!self::$inited)
+        {
+            self::init();
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        if (self::$directory)
+        {
+            self::$directory->delete();
+        }
+        parent::tearDownAfterClass();
+    }
+
+    /** @test */
+    public function can_get_password_strength_based_from_href()
+    {
+        $href = self::$directory->passwordPolicy->strength->href;
+
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get($href);
+
+        $this->assertInstanceOf(\Stormpath\Directory\PasswordStrength::class, $passwordStrength);
+    }
+
+    /** @test */
+    public function href_is_accessible()
+    {
+        $this->assertContains('/strength', self::$passwordStrength->getHref());
+        $this->assertContains('/strength', self::$passwordStrength->href);
+    }
+    
+    /** @test */
+    public function min_length_is_accessible()
+    {
+        $this->assertEquals(8, self::$passwordStrength->getMinLength());
+        $this->assertEquals(8, self::$passwordStrength->minLength);
+    }
+
+    /** @test */
+    public function min_length_is_savable()
+    {
+        self::$passwordStrength->setMinLength(6)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(6, $passwordStrength->getMinLength());
+
+
+        self::$passwordStrength->minLength = 8;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(8, $passwordStrength->getMinLength());
+    }
+
+
+    /** @test */
+    public function max_length_is_accessible()
+    {
+        $this->assertEquals(100, self::$passwordStrength->getMaxLength());
+        $this->assertEquals(100, self::$passwordStrength->maxLength);
+    }
+
+    /** @test */
+    public function max_length_is_savable()
+    {
+        self::$passwordStrength->setMaxLength(50)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(50, $passwordStrength->getMaxLength());
+
+
+        self::$passwordStrength->maxLength = 100;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(100, $passwordStrength->getMaxLength());
+    }
+
+    /** @test */
+    public function min_lower_case_is_accessible()
+    {
+        $this->assertEquals(1, self::$passwordStrength->getMinLowerCase());
+        $this->assertEquals(1, self::$passwordStrength->minLowerCase);
+    }
+
+    /** @test */
+    public function min_lower_case_is_savable()
+    {
+        self::$passwordStrength->setMinLowerCase(0)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getMinLowerCase());
+
+
+        self::$passwordStrength->minLowerCase = 1;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getMinLowerCase());
+    }
+
+    /** @test */
+    public function min_upper_case_is_accessible()
+    {
+        $this->assertEquals(1, self::$passwordStrength->getMinUpperCase());
+        $this->assertEquals(1, self::$passwordStrength->minUpperCase);
+    }
+
+    /** @test */
+    public function min_upper_case_is_savable()
+    {
+        self::$passwordStrength->setMinUpperCase(0)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getMinUpperCase());
+
+
+        self::$passwordStrength->minUpperCase = 1;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getMinUpperCase());
+    }
+
+    /** @test */
+    public function min_numeric_is_accessible()
+    {
+        $this->assertEquals(1, self::$passwordStrength->getMinNumeric());
+        $this->assertEquals(1, self::$passwordStrength->minNumeric);
+    }
+
+    /** @test */
+    public function min_numeric_is_savable()
+    {
+        self::$passwordStrength->setMinNumeric(0)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getMinNumeric());
+
+
+        self::$passwordStrength->minNumeric = 1;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getMinNumeric());
+    }
+
+    /** @test */
+    public function min_symbol_is_accessible()
+    {
+        $this->assertEquals(0, self::$passwordStrength->getMinSymbol());
+        $this->assertEquals(0, self::$passwordStrength->minSymbol);
+    }
+
+    /** @test */
+    public function min_symbol_is_savable()
+    {
+        self::$passwordStrength->setMinSymbol(1)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getMinSymbol());
+
+
+        self::$passwordStrength->minSymbol = 0;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getMinSymbol());
+    }
+
+    /** @test */
+    public function min_diacritic_is_accessible()
+    {
+        $this->assertEquals(0, self::$passwordStrength->getMinDiacritic());
+        $this->assertEquals(0, self::$passwordStrength->minDiacritic);
+    }
+
+    /** @test */
+    public function min_diacritic_is_savable()
+    {
+        self::$passwordStrength->setMinDiacritic(1)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getMinDiacritic());
+
+
+        self::$passwordStrength->minDiacritic = 0;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getMinDiacritic());
+    }
+
+    /** @test */
+    public function prevent_reuse_is_accessible()
+    {
+        $this->assertEquals(0, self::$passwordStrength->getPreventReuse());
+        $this->assertEquals(0, self::$passwordStrength->preventReuse);
+    }
+
+    /** @test */
+    public function prevent_reuse_is_savable()
+    {
+        self::$passwordStrength->setPreventReuse(1)->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(1, $passwordStrength->getPreventReuse());
+
+
+        self::$passwordStrength->preventReuse = 0;
+        self::$passwordStrength->save();
+        $passwordStrength = \Stormpath\Directory\PasswordStrength::get(self::$passwordStrength->href);
+        $this->assertEquals(0, $passwordStrength->getPreventReuse());
+    }
+
+
+
+    
+
+    
+    
+
+    
+
+}

--- a/tests/Mail/ModeledEmailTemplateListTest.php
+++ b/tests/Mail/ModeledEmailTemplateListTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Stormpath\Tests\Mail;
+
+use Stormpath\Mail\ModeledEmailTemplateList;
+use Stormpath\Tests\TestCase;
+
+class ModeledEmailTemplateListTest extends TestCase
+{
+    /** @test */
+    public function returns_correct_item_class_name()
+    {
+        $modeledEmailTemplateList = new ModeledEmailTemplateList();
+        $this->assertEquals('Stormpath\Mail\ModeledEmailTemplate', $modeledEmailTemplateList->getItemClassName());
+    }
+
+}

--- a/tests/Mail/ModeledEmailTemplateTest.php
+++ b/tests/Mail/ModeledEmailTemplateTest.php
@@ -281,6 +281,27 @@ class ModeledEmailTemplateTest extends TestCase
         static::$modeledEmailTemplate->save();
     }
 
+    /** @test */
+    public function the_email_template_can_be_saved()
+    {
+        $directory = \Stormpath\Resource\Directory::instantiate(array('name' => makeUniqueName('ModeledEmailTemplate'), 'description' => 'Main Directory description'));
+        self::createResource(\Stormpath\Resource\Directory::PATH, $directory);
+
+        foreach($directory->passwordPolicy->getResetEmailTemplates() as $emailTemplate) {
+            $emailTemplate->fromName = 'John Doe';
+            $emailTemplate->save();
+        }
+
+
+
+        foreach($directory->passwordPolicy->getResetEmailTemplates() as $emailTemplate) {
+            $this->assertEquals('John Doe', $emailTemplate->fromName);
+        }
+
+        $directory->delete();
+    }
+
+
 
 
 

--- a/tests/Mail/ModeledEmailTemplateTest.php
+++ b/tests/Mail/ModeledEmailTemplateTest.php
@@ -77,6 +77,14 @@ class ModeledEmailTemplateTest extends TestCase
     }
 
     /** @test */
+    public function href_is_accessible()
+    {
+        $this->assertEquals(static::$properties['href'], static::$modeledEmailTemplate->getHref());
+        $this->assertEquals(static::$properties['href'], static::$modeledEmailTemplate->href);
+
+    }
+
+    /** @test */
     public function name_is_accessible()
     {
         $this->assertEquals(static::$properties['name'], static::$modeledEmailTemplate->getName());

--- a/tests/Mail/ModeledEmailTemplateTest.php
+++ b/tests/Mail/ModeledEmailTemplateTest.php
@@ -1,0 +1,283 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Stormpath\Tests\Mail;
+
+use ReflectionClass;
+use Stormpath\Mail\ModeledEmailTemplate;
+use Stormpath\Mail\ModeledEmailTemplateList;
+use Stormpath\Stormpath;
+use Stormpath\Tests\TestCase;
+
+class ModeledEmailTemplateTest extends TestCase
+{
+    private static $modeledEmailTemplate;
+    private static $properties;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        static::$properties = [
+            'href' => 'https://api.stormpath.com/emailTemplates/2PCjpMa5kihBOo1eO8L6z5',
+            'name' => 'My Email',
+            'description' => 'My Description',
+            'fromName' => 'John Doe',
+            'fromEmailAddress' => 'john.doe@email.com',
+            'subject' => 'Your Password has been changed!',
+            'textBody' => 'Your password has been successfully changed',
+            'htmlBody' => 'Your password has been <b>successfully</b> changed',
+            'mimeType' => Stormpath::MIME_PLAIN_TEXT,
+            'defaultModel' => ['linkBaseUrl' => 'http://localhost:8000/passwordReset']
+        ];
+
+        $class = new \stdClass();
+
+        foreach(static::$properties as $prop=>$value)
+        {
+            $class->{$prop} = $value;
+        }
+
+        self::$modeledEmailTemplate = new ModeledEmailTemplate(null, $class);
+
+    }
+
+    /** @test */
+    public function constants_are_correct()
+    {
+        $reflection = new ReflectionClass(ModeledEmailTemplate::class);
+
+        $this->assertEquals('12', count($reflection->getConstants()));
+
+        $this->assertEquals('href', $reflection->getConstant('HREF_PROP_NAME'));
+        $this->assertEquals('name', $reflection->getConstant('NAME'));
+        $this->assertEquals('description', $reflection->getConstant('DESCRIPTION'));
+        $this->assertEquals('fromName', $reflection->getConstant('FROM_NAME'));
+        $this->assertEquals('fromEmailAddress', $reflection->getConstant('FROM_EMAIL_ADDRESS'));
+        $this->assertEquals('subject', $reflection->getConstant('SUBJECT'));
+        $this->assertEquals('textBody', $reflection->getConstant('TEXT_BODY'));
+        $this->assertEquals('htmlBody', $reflection->getConstant('HTML_BODY'));
+        $this->assertEquals('mimeType', $reflection->getConstant('MIME_TYPE'));
+        $this->assertEquals('emailTemplates', $reflection->getConstant('PATH'));
+        $this->assertEquals('defaultModel', $reflection->getConstant('DEFAULT_MODEL'));
+        $this->assertEquals('linkBaseUrl', $reflection->getConstant('LINK_BASE_URL'));
+    }
+
+    /** @test */
+    public function name_is_accessible()
+    {
+        $this->assertEquals(static::$properties['name'], static::$modeledEmailTemplate->getName());
+        $this->assertEquals(static::$properties['name'], static::$modeledEmailTemplate->name);
+    }
+
+    /** @test */
+    public function name_is_settable()
+    {
+        static::$modeledEmailTemplate->setName('New Email Name');
+        $this->assertEquals('New Email Name', static::$modeledEmailTemplate->getName());
+
+        static::$modeledEmailTemplate->name = 'Email Name';
+        $this->assertEquals('Email Name', static::$modeledEmailTemplate->getName());
+    }
+
+
+    /** @test */
+    public function description_is_accessible()
+    {
+        $this->assertEquals(static::$properties['description'], static::$modeledEmailTemplate->getDescription());
+        $this->assertEquals(static::$properties['description'], static::$modeledEmailTemplate->description);
+    }
+
+    /** @test */
+    public function description_is_settable()
+    {
+        static::$modeledEmailTemplate->setDescription('My New Description');
+        $this->assertEquals('My New Description', static::$modeledEmailTemplate->getDescription());
+
+        static::$modeledEmailTemplate->description = 'My Description';
+        $this->assertEquals('My Description', static::$modeledEmailTemplate->getDescription());
+    }
+
+    /** @test */
+    public function from_name_is_accessible()
+    {
+        $this->assertEquals(static::$properties['fromName'], static::$modeledEmailTemplate->getFromName());
+        $this->assertEquals(static::$properties['fromName'], static::$modeledEmailTemplate->fromName);
+    }
+
+    /** @test */
+    public function from_name_is_settable()
+    {
+        static::$modeledEmailTemplate->setFromName('John Doe Jr.');
+        $this->assertEquals('John Doe Jr.', static::$modeledEmailTemplate->getFromName());
+
+        static::$modeledEmailTemplate->fromName = 'John Doe';
+        $this->assertEquals('John Doe', static::$modeledEmailTemplate->getFromName());
+    }
+
+    /** @test */
+    public function from_email_address_is_accessible()
+    {
+        $this->assertEquals(static::$properties['fromEmailAddress'], static::$modeledEmailTemplate->getFromEmailAddress());
+        $this->assertEquals(static::$properties['fromEmailAddress'], static::$modeledEmailTemplate->fromEmailAddress);
+    }
+
+    /** @test */
+    public function from_email_address_is_settable()
+    {
+        static::$modeledEmailTemplate->setFromEmailAddress('john.doe.jr@example.com');
+        $this->assertEquals('john.doe.jr@example.com', static::$modeledEmailTemplate->getFromEmailAddress());
+
+        static::$modeledEmailTemplate->fromEmailAddress = 'john.doe@example.com';
+        $this->assertEquals('john.doe@example.com', static::$modeledEmailTemplate->getFromEmailAddress());
+    }
+
+    /** @test */
+    public function subject_is_accessible()
+    {
+        $this->assertEquals(static::$properties['subject'], static::$modeledEmailTemplate->getSubject());
+        $this->assertEquals(static::$properties['subject'], static::$modeledEmailTemplate->subject);
+    }
+
+    /** @test */
+    public function subject_is_settable()
+    {
+        static::$modeledEmailTemplate->setSubject('Your password has been reset');
+        $this->assertEquals('Your password has been reset', static::$modeledEmailTemplate->getSubject());
+
+        static::$modeledEmailTemplate->subject = 'Your Password has been changed!';
+        $this->assertEquals('Your Password has been changed!', static::$modeledEmailTemplate->getSubject());
+    }
+
+    /** @test */
+    public function text_body_is_accessible()
+    {
+        $this->assertEquals(static::$properties['textBody'], static::$modeledEmailTemplate->getTextBody());
+        $this->assertEquals(static::$properties['textBody'], static::$modeledEmailTemplate->textBody);
+    }
+
+    /** @test */
+    public function text_body_is_settable()
+    {
+        static::$modeledEmailTemplate->setTextBody('Your password has been successfully reset');
+        $this->assertEquals('Your password has been successfully reset', static::$modeledEmailTemplate->getTextBody());
+
+        static::$modeledEmailTemplate->textBody = 'Your password has been successfully changed';
+        $this->assertEquals('Your password has been successfully changed', static::$modeledEmailTemplate->getTextBody());
+    }
+
+    /** @test */
+    public function html_body_is_accessible()
+    {
+        $this->assertEquals(static::$properties['htmlBody'], static::$modeledEmailTemplate->getHtmlBody());
+        $this->assertEquals(static::$properties['htmlBody'], static::$modeledEmailTemplate->htmlBody);
+    }
+
+    /** @test */
+    public function html_body_is_settable()
+    {
+        static::$modeledEmailTemplate->setHtmlBody('Your password has been <b>successfully</b> reset.');
+        $this->assertEquals('Your password has been <b>successfully</b> reset.', static::$modeledEmailTemplate->getHtmlBody());
+
+        static::$modeledEmailTemplate->htmlBody = 'Your password has been <b>successfully</b> changed';
+        $this->assertEquals('Your password has been <b>successfully</b> changed', static::$modeledEmailTemplate->getHtmlBody());
+    }
+
+    /** @test */
+    public function mime_type_is_accessible()
+    {
+        $this->assertEquals(static::$properties['mimeType'], static::$modeledEmailTemplate->getMimeType());
+        $this->assertEquals(static::$properties['mimeType'], static::$modeledEmailTemplate->mimeType);
+    }
+
+    /** @test */
+    public function mime_type_is_settable()
+    {
+        static::$modeledEmailTemplate->setMimeType(Stormpath::MIME_HTML);
+        $this->assertEquals(Stormpath::MIME_HTML, static::$modeledEmailTemplate->getMimeType());
+
+        static::$modeledEmailTemplate->mimeType = Stormpath::MIME_PLAIN_TEXT;
+        $this->assertEquals(Stormpath::MIME_PLAIN_TEXT, static::$modeledEmailTemplate->getMimeType());
+    }
+
+
+
+    /** @test */
+    public function default_model_is_accessible()
+    {
+        $this->assertEquals(static::$properties['defaultModel'], static::$modeledEmailTemplate->getDefaultModel());
+        $this->assertEquals(static::$properties['defaultModel'], static::$modeledEmailTemplate->defaultModel);
+    }
+
+    /** @test */
+    public function default_model_is_settable()
+    {
+        static::$modeledEmailTemplate->setDefaultModel(['linkBaseUrl' => 'http://localhost:8000/newPasswordReset']);
+        $this->assertEquals(['linkBaseUrl' => 'http://localhost:8000/newPasswordReset'], static::$modeledEmailTemplate->getDefaultModel());
+
+        static::$modeledEmailTemplate->defaultModel = ['linkBaseUrl' => 'http://localhost:8000/passwordReset'];
+        $this->assertEquals(['linkBaseUrl' => 'http://localhost:8000/passwordReset'], static::$modeledEmailTemplate->getDefaultModel());
+    }
+
+    /** @test */
+    public function get_link_base_url_from_default_model()
+    {
+        static::$modeledEmailTemplate->defaultModel = ['linkBaseUrl' => 'http://localhost:8000/passwordReset'];
+
+        $this->assertEquals('http://localhost:8000/passwordReset', static::$modeledEmailTemplate->getLinkBaseUrl());
+        $this->assertEquals('http://localhost:8000/passwordReset', static::$modeledEmailTemplate->linkBaseUrl);
+    }
+
+    /** @test */
+    public function get_link_base_url_returns_null_if_none_is_defined()
+    {
+        static::$modeledEmailTemplate->defaultModel = [];
+        $this->assertNull(static::$modeledEmailTemplate->getLinkBaseUrl());
+        $this->assertNull(static::$modeledEmailTemplate->linkBaseUrl);
+    }
+
+    /** @test */
+    public function setting_link_base_url_returns_instance_of_modeled_email_template()
+    {
+        $chain = static::$modeledEmailTemplate->setLinkBaseUrl('http://localhost:8000/somethingElse');
+        $this->assertEquals('http://localhost:8000/somethingElse', static::$modeledEmailTemplate->getLinkBaseUrl());
+        $this->assertEquals('http://localhost:8000/somethingElse', static::$modeledEmailTemplate->linkBaseUrl);
+        $this->assertInstanceOf(ModeledEmailTemplate::class, $chain);
+
+        static::$modeledEmailTemplate->linkBaseUrl = 'http://localhost:8000/newPasswordReset';
+        $this->assertEquals('http://localhost:8000/newPasswordReset', static::$modeledEmailTemplate->getLinkBaseUrl());
+        $this->assertEquals('http://localhost:8000/newPasswordReset', static::$modeledEmailTemplate->linkBaseUrl);
+    }
+
+    /**
+     * @test
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function it_throws_exception_if_saving_without_link_base_url()
+    {
+        static::$modeledEmailTemplate->defaultModel = [];
+        static::$modeledEmailTemplate->save();
+    }
+
+
+
+
+
+
+
+
+}

--- a/tests/Mail/UnmodeledEmailTemplateListTest.php
+++ b/tests/Mail/UnmodeledEmailTemplateListTest.php
@@ -1,0 +1,31 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Stormpath\Tests\Mail;
+
+use Stormpath\Mail\UnmodeledEmailTemplateList;
+use Stormpath\Tests\TestCase;
+
+class UnmodeledEmailTemplateListTest extends TestCase
+{
+    /** @test */
+    public function returns_correct_item_class_name()
+    {
+        $modeledEmailTemplateList = new UnmodeledEmailTemplateList();
+        $this->assertEquals('Stormpath\Mail\UnmodeledEmailTemplate', $modeledEmailTemplateList->getItemClassName());
+    }
+
+}

--- a/tests/Mail/UnmodeledEmailTemplateTest.php
+++ b/tests/Mail/UnmodeledEmailTemplateTest.php
@@ -1,0 +1,251 @@
+<?php
+/*
+ * Copyright 2016 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace Stormpath\Tests\Mail;
+
+use ReflectionClass;
+use Stormpath\Mail\UnmodeledEmailTemplate;
+use Stormpath\Mail\UnmodeledEmailTemplateList;
+use Stormpath\Stormpath;
+use Stormpath\Tests\TestCase;
+
+class ModeledEmailTemplateTest extends TestCase
+{
+    private static $modeledEmailTemplate;
+    private static $properties;
+
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+
+        static::$properties = [
+            'href' => 'https://api.stormpath.com/emailTemplates/2PCjpMa5kihBOo1eO8L6z5',
+            'name' => 'My Email',
+            'description' => 'My Description',
+            'fromName' => 'John Doe',
+            'fromEmailAddress' => 'john.doe@email.com',
+            'subject' => 'Your Password has been changed!',
+            'textBody' => 'Your password has been successfully changed',
+            'htmlBody' => 'Your password has been <b>successfully</b> changed',
+            'mimeType' => Stormpath::MIME_PLAIN_TEXT
+        ];
+
+        $class = new \stdClass();
+
+        foreach(static::$properties as $prop=>$value)
+        {
+            $class->{$prop} = $value;
+        }
+
+        self::$modeledEmailTemplate = new UnmodeledEmailTemplate(null, $class);
+
+    }
+
+    /** @test */
+    public function constants_are_correct()
+    {
+        $reflection = new ReflectionClass(UnmodeledEmailTemplate::class);
+
+        $this->assertEquals('10', count($reflection->getConstants()));
+
+        $this->assertEquals('href', $reflection->getConstant('HREF_PROP_NAME'));
+        $this->assertEquals('name', $reflection->getConstant('NAME'));
+        $this->assertEquals('description', $reflection->getConstant('DESCRIPTION'));
+        $this->assertEquals('fromName', $reflection->getConstant('FROM_NAME'));
+        $this->assertEquals('fromEmailAddress', $reflection->getConstant('FROM_EMAIL_ADDRESS'));
+        $this->assertEquals('subject', $reflection->getConstant('SUBJECT'));
+        $this->assertEquals('textBody', $reflection->getConstant('TEXT_BODY'));
+        $this->assertEquals('htmlBody', $reflection->getConstant('HTML_BODY'));
+        $this->assertEquals('mimeType', $reflection->getConstant('MIME_TYPE'));
+        $this->assertEquals('emailTemplates', $reflection->getConstant('PATH'));
+    }
+
+    /** @test */
+    public function href_is_accessible()
+    {
+        $this->assertEquals(static::$properties['href'], static::$modeledEmailTemplate->getHref());
+        $this->assertEquals(static::$properties['href'], static::$modeledEmailTemplate->href);
+
+    }
+
+    /** @test */
+    public function name_is_accessible()
+    {
+        $this->assertEquals(static::$properties['name'], static::$modeledEmailTemplate->getName());
+        $this->assertEquals(static::$properties['name'], static::$modeledEmailTemplate->name);
+    }
+
+    /** @test */
+    public function name_is_settable()
+    {
+        static::$modeledEmailTemplate->setName('New Email Name');
+        $this->assertEquals('New Email Name', static::$modeledEmailTemplate->getName());
+
+        static::$modeledEmailTemplate->name = 'Email Name';
+        $this->assertEquals('Email Name', static::$modeledEmailTemplate->getName());
+    }
+
+
+    /** @test */
+    public function description_is_accessible()
+    {
+        $this->assertEquals(static::$properties['description'], static::$modeledEmailTemplate->getDescription());
+        $this->assertEquals(static::$properties['description'], static::$modeledEmailTemplate->description);
+    }
+
+    /** @test */
+    public function description_is_settable()
+    {
+        static::$modeledEmailTemplate->setDescription('My New Description');
+        $this->assertEquals('My New Description', static::$modeledEmailTemplate->getDescription());
+
+        static::$modeledEmailTemplate->description = 'My Description';
+        $this->assertEquals('My Description', static::$modeledEmailTemplate->getDescription());
+    }
+
+    /** @test */
+    public function from_name_is_accessible()
+    {
+        $this->assertEquals(static::$properties['fromName'], static::$modeledEmailTemplate->getFromName());
+        $this->assertEquals(static::$properties['fromName'], static::$modeledEmailTemplate->fromName);
+    }
+
+    /** @test */
+    public function from_name_is_settable()
+    {
+        static::$modeledEmailTemplate->setFromName('John Doe Jr.');
+        $this->assertEquals('John Doe Jr.', static::$modeledEmailTemplate->getFromName());
+
+        static::$modeledEmailTemplate->fromName = 'John Doe';
+        $this->assertEquals('John Doe', static::$modeledEmailTemplate->getFromName());
+    }
+
+    /** @test */
+    public function from_email_address_is_accessible()
+    {
+        $this->assertEquals(static::$properties['fromEmailAddress'], static::$modeledEmailTemplate->getFromEmailAddress());
+        $this->assertEquals(static::$properties['fromEmailAddress'], static::$modeledEmailTemplate->fromEmailAddress);
+    }
+
+    /** @test */
+    public function from_email_address_is_settable()
+    {
+        static::$modeledEmailTemplate->setFromEmailAddress('john.doe.jr@example.com');
+        $this->assertEquals('john.doe.jr@example.com', static::$modeledEmailTemplate->getFromEmailAddress());
+
+        static::$modeledEmailTemplate->fromEmailAddress = 'john.doe@example.com';
+        $this->assertEquals('john.doe@example.com', static::$modeledEmailTemplate->getFromEmailAddress());
+    }
+
+    /** @test */
+    public function subject_is_accessible()
+    {
+        $this->assertEquals(static::$properties['subject'], static::$modeledEmailTemplate->getSubject());
+        $this->assertEquals(static::$properties['subject'], static::$modeledEmailTemplate->subject);
+    }
+
+    /** @test */
+    public function subject_is_settable()
+    {
+        static::$modeledEmailTemplate->setSubject('Your password has been reset');
+        $this->assertEquals('Your password has been reset', static::$modeledEmailTemplate->getSubject());
+
+        static::$modeledEmailTemplate->subject = 'Your Password has been changed!';
+        $this->assertEquals('Your Password has been changed!', static::$modeledEmailTemplate->getSubject());
+    }
+
+    /** @test */
+    public function text_body_is_accessible()
+    {
+        $this->assertEquals(static::$properties['textBody'], static::$modeledEmailTemplate->getTextBody());
+        $this->assertEquals(static::$properties['textBody'], static::$modeledEmailTemplate->textBody);
+    }
+
+    /** @test */
+    public function text_body_is_settable()
+    {
+        static::$modeledEmailTemplate->setTextBody('Your password has been successfully reset');
+        $this->assertEquals('Your password has been successfully reset', static::$modeledEmailTemplate->getTextBody());
+
+        static::$modeledEmailTemplate->textBody = 'Your password has been successfully changed';
+        $this->assertEquals('Your password has been successfully changed', static::$modeledEmailTemplate->getTextBody());
+    }
+
+    /** @test */
+    public function html_body_is_accessible()
+    {
+        $this->assertEquals(static::$properties['htmlBody'], static::$modeledEmailTemplate->getHtmlBody());
+        $this->assertEquals(static::$properties['htmlBody'], static::$modeledEmailTemplate->htmlBody);
+    }
+
+    /** @test */
+    public function html_body_is_settable()
+    {
+        static::$modeledEmailTemplate->setHtmlBody('Your password has been <b>successfully</b> reset.');
+        $this->assertEquals('Your password has been <b>successfully</b> reset.', static::$modeledEmailTemplate->getHtmlBody());
+
+        static::$modeledEmailTemplate->htmlBody = 'Your password has been <b>successfully</b> changed';
+        $this->assertEquals('Your password has been <b>successfully</b> changed', static::$modeledEmailTemplate->getHtmlBody());
+    }
+
+    /** @test */
+    public function mime_type_is_accessible()
+    {
+        $this->assertEquals(static::$properties['mimeType'], static::$modeledEmailTemplate->getMimeType());
+        $this->assertEquals(static::$properties['mimeType'], static::$modeledEmailTemplate->mimeType);
+    }
+
+    /** @test */
+    public function mime_type_is_settable()
+    {
+        static::$modeledEmailTemplate->setMimeType(Stormpath::MIME_HTML);
+        $this->assertEquals(Stormpath::MIME_HTML, static::$modeledEmailTemplate->getMimeType());
+
+        static::$modeledEmailTemplate->mimeType = Stormpath::MIME_PLAIN_TEXT;
+        $this->assertEquals(Stormpath::MIME_PLAIN_TEXT, static::$modeledEmailTemplate->getMimeType());
+    }
+
+
+
+    /** @test */
+    public function the_email_template_can_be_saved()
+    {
+        $directory = \Stormpath\Resource\Directory::instantiate(array('name' => makeUniqueName('ModeledEmailTemplate'), 'description' => 'Main Directory description'));
+        self::createResource(\Stormpath\Resource\Directory::PATH, $directory);
+
+        foreach($directory->passwordPolicy->getResetSuccessEmailTemplates() as $emailTemplate) {
+            $emailTemplate->fromName = 'John Doe';
+            $emailTemplate->save();
+        }
+
+
+
+        foreach($directory->passwordPolicy->getResetSuccessEmailTemplates() as $emailTemplate) {
+            $this->assertEquals('John Doe', $emailTemplate->fromName);
+        }
+
+        $directory->delete();
+    }
+
+
+
+
+
+
+
+
+
+}

--- a/tests/Mail/UnmodeledEmailTemplateTest.php
+++ b/tests/Mail/UnmodeledEmailTemplateTest.php
@@ -22,7 +22,7 @@ use Stormpath\Mail\UnmodeledEmailTemplateList;
 use Stormpath\Stormpath;
 use Stormpath\Tests\TestCase;
 
-class ModeledEmailTemplateTest extends TestCase
+class UnmodeledEmailTemplateTest extends TestCase
 {
     private static $modeledEmailTemplate;
     private static $properties;

--- a/tests/Resource/DirectoryTest.php
+++ b/tests/Resource/DirectoryTest.php
@@ -60,6 +60,7 @@ class DirectoryTest extends \Stormpath\Tests\TestCase {
         $this->assertInstanceOf('\Stormpath\Resource\AccountList', $directory->accounts);
         $this->assertInstanceOf('\Stormpath\Resource\Tenant', $directory->tenant);
         $this->assertEquals(self::$client->tenant->name, $directory->tenant->name);
+        $this->assertInstanceOf('\Stormpath\Directory\PasswordPolicy', $directory->passwordPolicy);
     }
 
     public function testCreate()


### PR DESCRIPTION
This set of changes gives the ability to work with the Password Policy of a directory. This resolves #106  

Usage 
=====

### Get the Password Policy from the directory
```
$passwordPolicy = $directory->getPasswordPolicy();
```

#### Properties from PasswordPolicy

##### Getting individual properties
```
$resetTokenTtl = $passwordPolicy->getResetTokenTtl();
$resetEmailStatus = $passwordPolicy->getEmailStatus();
$resetSuccessEmailStatus = $passwordPolicy->getSuccessEmailStatus();
```

##### Setting Properties
All setters are chainable
```
$passwordPolicy->setResetTokenTtl(12)
                            ->setEmailStatus(\Stormpath\Stormpath::ENABLED) //or ::DISABLED
                            ->setSuccessEmailStatus(\Stormpath\Stormpath::ENABLED) //or ::DISABLED
                            ->save();
```

#### Resource Properties from Password Policy
```
$strength = $passwordPolicy->getStrength();
$resetEmailTemplates = $passwordPolicy->getResetEmailTemplates();
$resetSuccessEmailTemplates = $passwordPolicy->getResetSuccessEmailTemplates();
```

#### Strength Properties
A single resource will be returned when calling `getStrength()` from the password policy

Getting individual properties
```
$minLength = $strength->getMinLength();
$maxLength = $strength->getMaxLength();
$minLowerCase = $strength->getMinLowerCase();
$minUpperCase = $strength->getMinUpperCase();
$minNumeric = $strength->getMinNumeric();
$minSymbol = $strength->getMinSymbol();
$minDiacritic = $strength->getMinDiacritic();
$preventReuse = $strength->getPreventReuse();
```

Setting properties is the same as above.  All methods are chainable and should end with `save()`.  Just change `get` to `set`.

#### ResetEmailTemplate Properties
When you request the reset email templates, a list will be returned,  once you get a single item from the list, you will have access to the followeing properties.

```
$resetEmailTemplate->getHref();
$resetEmailTemplate->getName();
$resetEmailTemplate->getDescription();
$resetEmailTemplate->getFromName();
$resetEmailTemplate->getFromEmailAddress();
$resetEmailTemplate->getSubject();
$resetEmailTemplate->getTextBody();
$resetEmailTemplate->getHtmlBody();
$resetEmailTemplate->getMimeType();
$resetEmailTemplate->getDefaultModel();
```

Mime Type is avabile to be set with the Stormpath Constants `\Stormpath\Stormpath::MIME_HTML` or `\Stormpath\Stormpath::MIMIE_PLAIN_TEXT`

Default Model is the location that has the `linkBaseUrl` that defines the url the user will click on.  This can be set with `setDefaultModel` and passing in an array, or using the `setLinkBaseUrl` methods and only passing in the URL.

Setting the proties are the same as above where you change `get` with `set` and all methods are chainable.

#### ResetSuccessEmailTemplate Properties
When you request the reset success email templates, a list will be returned,  once you get a single item from the list, you will have access to the followeing properties.

```
$resetEmailTemplate->getHref();
$resetEmailTemplate->getName();
$resetEmailTemplate->getDescription();
$resetEmailTemplate->getFromName();
$resetEmailTemplate->getFromEmailAddress();
$resetEmailTemplate->getSubject();
$resetEmailTemplate->getTextBody();
$resetEmailTemplate->getHtmlBody();
$resetEmailTemplate->getMimeType();
```

Mime Type is avabile to be set with the Stormpath Constants `\Stormpath\Stormpath::MIME_HTML` or `\Stormpath\Stormpath::MIMIE_PLAIN_TEXT`

Setting the proties are the same as above where you change `get` with `set` and all methods are chainable.