### PR TITLE
adds ability to work with account creation policy emails

### DIFF
--- a/src/Resource/AccountCreationPolicy.php
+++ b/src/Resource/AccountCreationPolicy.php
@@ -17,11 +17,16 @@
 
 namespace Stormpath\Resource;
 
+use Stormpath\Stormpath;
+
 class AccountCreationPolicy extends InstanceResource implements Saveable {
 
-    const VERIFICATION_EMAIL_STATUS             = 'verificationEmailStatus';
     const WELCOME_EMAIL_STATUS                  = 'welcomeEmailStatus';
+    const WELCOME_EMAIL_TEMPLATES               = 'welcomeEmailTemplates';
+    const VERIFICATION_EMAIL_STATUS             = 'verificationEmailStatus';
+    const VERIFICATION_EMAIL_TEMPLATES          = 'verificationEmailTemplates';
     const VERIFICATION_SUCCESS_EMAIL_STATUS     = 'verificationSuccessEmailStatus';
+    const VERIFICATION_SUCCESS_EMAIL_TEMPLATES  = 'verificationSuccessEmailTemplates';
 
     public function setVerificationEmailStatus($status)
     {
@@ -51,5 +56,20 @@ class AccountCreationPolicy extends InstanceResource implements Saveable {
     public function getVerificationSuccessEmailStatus()
     {
         return $this->getProperty(self::VERIFICATION_SUCCESS_EMAIL_STATUS);
+    }
+
+    public function getVerificationEmailTemplates(array $options = [])
+    {
+        return $this->getResourceProperty(self::VERIFICATION_EMAIL_TEMPLATES, Stormpath::MODELED_EMAIL_TEMPLATE_LIST, $options);
+    }
+
+    public function getVerificationSuccessEmailTemplates(array $options = [])
+    {
+        return $this->getResourceProperty(self::VERIFICATION_SUCCESS_EMAIL_TEMPLATES, Stormpath::UNMODELED_EMAIL_TEMPLATE_LIST, $options);
+    }
+
+    public function getWelcomeEmailTemplates(array $options = [])
+    {
+        return $this->getResourceProperty(self::WELCOME_EMAIL_TEMPLATES, Stormpath::UNMODELED_EMAIL_TEMPLATE_LIST, $options);
     }
 }

--- a/tests/Resource/AccountCreationPolicyTest.php
+++ b/tests/Resource/AccountCreationPolicyTest.php
@@ -85,6 +85,28 @@ class AccountCreationPolicyTest extends \Stormpath\Tests\TestCase {
         $this->disableAndTest('welcomeEmailStatus');
     }
 
+    /** @test */
+    public function accessor_for_verification_email_templates_returns_modeled_email_template_list_resource()
+    {
+        $verificationEmailTemplates = self::$acp->getVerificationEmailTemplates();
+        $this->assertInstanceOf(\Stormpath\Mail\ModeledEmailTemplateList::class, $verificationEmailTemplates);
+    }
+
+    /** @test */
+    public function accessor_for_verification_success_email_templates_returns_unmodeled_email_template_list_resource()
+    {
+        $verificationSuccessEmailTemplates = self::$acp->getVerificationSuccessEmailTemplates();
+        $this->assertInstanceOf(\Stormpath\Mail\UnmodeledEmailTemplateList::class, $verificationSuccessEmailTemplates);
+    }
+
+    /** @test */
+    public function accessor_for_welcome_email_templates_returns_unmodeled_email_template_list_resource()
+    {
+        $welcomeEmailTemplates = self::$acp->getWelcomeEmailTemplates();
+        $this->assertInstanceOf(\Stormpath\Mail\UnmodeledEmailTemplateList::class, $welcomeEmailTemplates);
+    }
+
+
     public static function tearDownAfterClass()
     {
         self::$directory->delete();


### PR DESCRIPTION
This PR resolves #150.  It provides 3 new methods on the Account Creation Policy resource.  

```
$verificationEmailTemplates = $accountCreationPolicy->getVerificationEmailTemplates();
$verificationSuccessEmailTemplates = $accountCreationPolicy->getVerificationSuccessEmailTemplates();
$welcomeEmailTemplates = $accountCreationPolicy->getWelcomeEmailTemplates();
```

Working with the Email templates can be found in PR #165 