### PR TITLE
Add email blacklist and whitelist

### DIFF
--- a/src/Resource/AccountCreationPolicy.php
+++ b/src/Resource/AccountCreationPolicy.php
@@ -22,6 +22,8 @@ use Stormpath\Stormpath;
 class AccountCreationPolicy extends InstanceResource implements Saveable {
 
     const WELCOME_EMAIL_STATUS                  = 'welcomeEmailStatus';
+    const EMAIL_DOMAIN_WHITELIST                = 'emailDomainWhitelist';
+    const EMAIL_DOMAIN_BLACKLIST                = 'emailDomainBlacklist';
     const WELCOME_EMAIL_TEMPLATES               = 'welcomeEmailTemplates';
     const VERIFICATION_EMAIL_STATUS             = 'verificationEmailStatus';
     const VERIFICATION_EMAIL_TEMPLATES          = 'verificationEmailTemplates';
@@ -72,4 +74,99 @@ class AccountCreationPolicy extends InstanceResource implements Saveable {
     {
         return $this->getResourceProperty(self::WELCOME_EMAIL_TEMPLATES, Stormpath::UNMODELED_EMAIL_TEMPLATE_LIST, $options);
     }
+
+    /**
+     * Gets the emailDomainWhitelist property
+     *
+     * @return array
+     */
+    public function getEmailDomainWhitelist()
+    {
+        return $this->getProperty(self::EMAIL_DOMAIN_WHITELIST);
+    }
+
+    public function addEmailDomainWhitelist($domain)
+    {
+        if(!is_string($domain)) throw new \InvalidArgumentException('Domain must be a string');
+
+        $whitelist = $this->getProperty(self::EMAIL_DOMAIN_WHITELIST);
+        $whitelist[] = $domain;
+        $this->setEmailDomainWhitelist(array_unique($whitelist));
+    }
+
+    public function removeEmailDomainWhitelist($domain)
+    {
+        $whitelist = $this->getProperty(self::EMAIL_DOMAIN_WHITELIST);
+
+        $key = array_search($domain, $whitelist);
+        if($key !== false) {
+            unset($whitelist[$key]);
+        }
+
+        $this->setEmailDomainWhitelist(array_unique($whitelist));
+    }
+    
+    /**
+     * Sets the emailDomainWhitelist property
+     *
+     * @param  $emailDomainWhitelist The emailDomainWhitelist of the object
+     * @return self
+     */
+    public function setEmailDomainWhitelist($emailDomainWhitelist)
+    {
+        $this->setProperty(self::EMAIL_DOMAIN_WHITELIST, $emailDomainWhitelist);
+        
+        return $this; 
+    } 
+    
+    
+
+    /**
+     * Gets the emailDomainBlacklist property
+     *
+     * @return
+     */
+    public function getEmailDomainBlacklist()
+    {
+        return $this->getProperty(self::EMAIL_DOMAIN_BLACKLIST);
+    }
+
+
+    public function addEmailDomainBlacklist($domain)
+    {
+        if(!is_string($domain)) throw new \InvalidArgumentException('Domain must be a string');
+
+        $blacklist = $this->getProperty(self::EMAIL_DOMAIN_BLACKLIST);
+        $blacklist[] = $domain;
+        $this->setEmailDomainBlacklist(array_unique($blacklist));
+    }
+
+    public function removeEmailDomainBlacklist($domain)
+    {
+        $blacklist = $this->getProperty(self::EMAIL_DOMAIN_BLACKLIST);
+
+        $key = array_search($domain, $blacklist);
+        if($key !== false) {
+            unset($blacklist[$key]);
+        }
+
+        $this->setEmailDomainBlacklist(array_unique($blacklist));
+    }
+
+    /**
+     * Sets the emailDomainBlacklist property
+     *
+     * @param  $emailDomainBlacklist The emailDomainBlacklist of the object
+     * @return self
+     */
+    public function setEmailDomainBlacklist($emailDomainBlacklist)
+    {
+        $this->setProperty(self::EMAIL_DOMAIN_BLACKLIST, $emailDomainBlacklist);
+
+        return $this;
+    }
+
+
+
+
 }

--- a/tests/Resource/AccountCreationPolicyTest.php
+++ b/tests/Resource/AccountCreationPolicyTest.php
@@ -106,6 +106,142 @@ class AccountCreationPolicyTest extends \Stormpath\Tests\TestCase {
         $this->assertInstanceOf(\Stormpath\Mail\UnmodeledEmailTemplateList::class, $welcomeEmailTemplates);
     }
 
+    /** @test */
+    public function email_domain_whitelist_returns_array()
+    {
+        $emailWhitelist = self::$acp->getEmailDomainWhitelist();
+        $this->assertTrue(is_array($emailWhitelist));
+    }
+
+    /** @test */
+    public function ability_to_set_domain_whitelist()
+    {
+        $this->assertEmpty(self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->setEmailDomainWhitelist(['abc.com', 'xyz.com']);
+
+        $this->assertCount(2, self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->setEmailDomainWhitelist([]);
+
+        $this->assertCount(0, self::$acp->getEmailDomainWhitelist());
+
+    }
+
+
+    /** @test */
+    public function ability_to_add_domain_whitelist()
+    {
+        $this->assertEmpty(self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->addEmailDomainWhitelist('gmail.com');
+        self::$acp->addEmailDomainWhitelist('stormpath.com');
+        self::$acp->addEmailDomainWhitelist('stormpath.com');
+
+        $this->assertCount(2, self::$acp->getEmailDomainWhitelist());
+
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function must_pass_string_to_add_domain_whitelist()
+    {
+        self::$acp->addEmailDomainWhitelist(['gmail.com']);
+    }
+
+
+    /** @test */
+    public function ability_to_remove_single_whitelist_domain()
+    {
+        self::$acp->setEmailDomainWhitelist([]);
+        self::$acp->addEmailDomainWhitelist('gmail.com');
+        self::$acp->addEmailDomainWhitelist('stormpath.com');
+        self::$acp->addEmailDomainWhitelist('xyz.com');
+        $this->assertCount(3, self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->removeEmailDomainWhitelist('xyz.com');
+        $this->assertCount(2, self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->removeEmailDomainWhitelist('gmail.com');
+        $this->assertCount(1, self::$acp->getEmailDomainWhitelist());
+
+        self::$acp->removeEmailDomainWhitelist('blah.com');
+        $this->assertCount(1, self::$acp->getEmailDomainWhitelist());
+
+    }
+
+
+
+    /** @test */
+    public function email_domain_blacklist_returns_array()
+    {
+        $emailBlacklist = self::$acp->getEmailDomainBlacklist();
+        $this->assertTrue(is_array($emailBlacklist));
+    }
+
+
+    /** @test */
+    public function ability_to_set_domain_blacklist()
+    {
+        $this->assertEmpty(self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->setEmailDomainBlacklist(['abc.com', 'xyz.com']);
+
+        $this->assertCount(2, self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->setEmailDomainBlacklist([]);
+
+        $this->assertCount(0, self::$acp->getEmailDomainBlacklist());
+
+    }
+
+
+    /** @test */
+    public function ability_to_add_domain_blacklist()
+    {
+        $this->assertEmpty(self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->addEmailDomainBlacklist('gmail.com');
+        self::$acp->addEmailDomainBlacklist('stormpath.com');
+        self::$acp->addEmailDomainBlacklist('stormpath.com');
+
+        $this->assertCount(2, self::$acp->getEmailDomainBlacklist());
+
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+    public function must_pass_string_to_add_domain_blacklist()
+    {
+        self::$acp->addEmailDomainBlacklist(['gmail.com']);
+    }
+
+
+    /** @test */
+    public function ability_to_remove_single_blacklist_domain()
+    {
+        self::$acp->setEmailDomainBlacklist([]);
+        self::$acp->addEmailDomainBlacklist('gmail.com');
+        self::$acp->addEmailDomainBlacklist('stormpath.com');
+        self::$acp->addEmailDomainBlacklist('xyz.com');
+        $this->assertCount(3, self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->removeEmailDomainBlacklist('xyz.com');
+        $this->assertCount(2, self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->removeEmailDomainBlacklist('gmail.com');
+        $this->assertCount(1, self::$acp->getEmailDomainBlacklist());
+
+        self::$acp->removeEmailDomainBlacklist('blah.com');
+        $this->assertCount(1, self::$acp->getEmailDomainBlacklist());
+
+    }
+    
+
 
     public static function tearDownAfterClass()
     {


### PR DESCRIPTION
This resolves #160.  

Documentation
============

Replacing the domain blacklist with a full array.
```
$acp->setEmailDomainBlacklist(['abc.com', 'xyz.com']); 
$acp->getEmailDomainBlacklist(); //returns ['abc.com', 'xyz.com']
```

Adding an item to the domain blacklist array (when starting with an empty array)
```
$acp->addEmailDomainBlacklist('gmail.com');
$acp->addEmailDomainBlacklist('stormpath.com');
$acp->getEmailDomainBlacklist(); //returns ['gmail.com', 'stormpath.com']
```

Remove a domain from the list (starting with ['stormpath.com', 'xyz.com']
```
$acp->removeEmailDomainBlacklist('xyz.com');
$acp->getEmailDomainBlacklist(); //returns ['stormpath.com']
```

Clear domains from list
```
$acp->setEmailDomainBlacklist([]);
```

All functions are the same for whitelist, when changing `Blacklist` to `Whitelist`