### PR TITLE
adds request id to resource error and error

### DIFF
--- a/src/Resource/Error.php
+++ b/src/Resource/Error.php
@@ -25,6 +25,7 @@ class Error extends Resource
     const MESSAGE     = "message";
     const DEV_MESSAGE = "developerMessage";
     const MORE_INFO   = "moreInfo";
+    const REQUEST_ID  = "requestId";
 
     public function __construct(\stdClass $properties)
     {
@@ -54,6 +55,11 @@ class Error extends Resource
     public function getMoreInfo()
     {
         return $this->getProperty(self::MORE_INFO);
+    }
+
+    public function getRequestId()
+    {
+        return $this->getProperty(self::REQUEST_ID);
     }
 
 }

--- a/src/Resource/ResourceError.php
+++ b/src/Resource/ResourceError.php
@@ -47,4 +47,9 @@ class ResourceError extends \RuntimeException
     {
         return $this->error ? $this->error->getMoreInfo() : null;
     }
+
+    public function getRequestId()
+    {
+        return $this->error ? $this->error->getRequestId() : null;
+    }
 }

--- a/tests/Resource/ApplicationTest.php
+++ b/tests/Resource/ApplicationTest.php
@@ -724,6 +724,7 @@ class ApplicationTest extends \Stormpath\Tests\TestCase {
             $this->assertContains('Invalid', $re->getMessage());
             $this->assertEquals("Login attempt failed because there is no Account in the Application's associated Account Stores with the specified username or email.", $re->getDeveloperMessage());
             $this->assertContains('7104', $re->getMoreInfo());
+            $this->assertNotNull($re->getRequestId());
         }
 
         try


### PR DESCRIPTION
Resolves #155 

The Stormpath API now provides a request id for troubleshooting.  The PHP SDK has now added the ability to retrieve this.

```
$resourceError->getRequestId();
```