### PR TITLE
updates to allow for name and description for api key

### DIFF
--- a/src/Resource/Account.php
+++ b/src/Resource/Account.php
@@ -233,7 +233,12 @@ class Account extends InstanceResource implements Deletable
         $apiKeyOptions = new ApiKeyEncryptionOptions($options);
         $options = array_merge($options, $apiKeyOptions->toArray());
 
-        $apiKey = $this->getDataStore()->instantiate(Stormpath::API_KEY);
+        $properties = new \stdClass();
+
+        if(isset($options['name'])) { $properties->name = $options['name']; }
+        if(isset($options['description'])) { $properties->description = $options['description']; }
+
+        $apiKey = $this->getDataStore()->instantiate(Stormpath::API_KEY, $properties);
 
         $apiKey = $this->getDataStore()->create($this->getHref() . '/' . ApiKey::PATH,
             $apiKey, Stormpath::API_KEY, $options);

--- a/src/Resource/ApiKey.php
+++ b/src/Resource/ApiKey.php
@@ -24,14 +24,17 @@ use Stormpath\Stormpath;
 
 class ApiKey extends InstanceResource implements Deletable
 {
-    const ID        = "id";
-    const SECRET    = "secret";
-    const STATUS    = "status";
+    const ID            = "id";
+    const SECRET        = "secret";
+    const STATUS        = "status";
+    
+    const NAME          = "name";
+    const DESCRIPTION   = "description";
 
-    const ACCOUNT   = "account";
-    const TENANT    = "tenant";
+    const ACCOUNT       = "account";
+    const TENANT        = "tenant";
 
-    const PATH      = "apiKeys";
+    const PATH          = "apiKeys";
 
     private $apiKeyMetadata;
 
@@ -78,6 +81,58 @@ class ApiKey extends InstanceResource implements Deletable
     {
         $this->apiKeyMetadata = $metadata;
     }
+    
+    /**
+     * Gets the name property
+     *
+     * @return 
+     */
+    public function getName()
+    {
+        return $this->getProperty(self::NAME);
+    }
+
+    /**
+     * Sets the name property
+     *
+     * @param string $name The name of the object
+     * @return self
+     */
+    public function setName($name)
+    {
+        $this->setProperty(self::NAME, $name);
+
+        return $this;
+    }
+
+
+    
+    /**
+     * Gets the description property
+     *
+     * @return 
+     */
+    public function getDescription()
+    {
+        return $this->getProperty(self::DESCRIPTION);
+    } 
+    
+    /**
+     * Sets the description property
+     *
+     * @param string $description The description of the object
+     * @return self
+     */
+    public function setDescription($description)
+    {
+        $this->setProperty(self::DESCRIPTION, $description);
+
+        return $this;
+    }
+
+
+    
+    
 
     public function delete()
     {

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -238,14 +238,28 @@ class AccountTest extends \Stormpath\Tests\TestCase {
     public function testApiKey()
     {
         $account = self::$account;
-        $apiKey = $account->createApiKey();
+        $apiKey = $account->createApiKey([
+            'name' => 'Test Api Key',
+            'description' => 'Description'
+        ]);
 
         $this->assertNotEmpty($apiKey->id);
         $this->assertNotEmpty($apiKey->secret);
         $this->assertNotEmpty($apiKey->status);
-        
+        $this->assertEquals('Test Api Key', $apiKey->getName());
+        $this->assertEquals('Description', $apiKey->getDescription());
+
+
+        $apiKey->setName('Name');
+        $apiKey->setDescription('Desc');
+
+        $this->assertEquals('Name', $apiKey->getName());
+        $this->assertEquals('Desc', $apiKey->getDescription());
+
         $this->assertEquals($account->href, $apiKey->account->href);
+        $this->assertContains('/tenants/', $apiKey->tenant->href);
     }
+
 
     public function testGroupsOptions()
     {

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -258,6 +258,10 @@ class AccountTest extends \Stormpath\Tests\TestCase {
 
         $this->assertEquals($account->href, $apiKey->account->href);
         $this->assertContains('/tenants/', $apiKey->tenant->href);
+
+        $apiKey2 = $account->createApiKey();
+        $this->assertNull($apiKey2->getName());
+        $this->assertNull($apiKey2->getDescription());
     }
 
 


### PR DESCRIPTION
resolves issue #156 

```
$apiKey = $account->createApiKey([
    'name' => 'Api Key Name',
    'description' => 'Api Key Description
]);

$apiKey->getName(); // Api Key Name
$apiKey->getDescription(); // Api Key Description

$apiKey->setName('Test Api Key');
$apiKey->setDescription('Just a Test Key');
```