### PR TITLE
Set timezone on DateTime object instead of overriding globally.

### DIFF
--- a/src/Http/Authc/BasicRequestSigner.php
+++ b/src/Http/Authc/BasicRequestSigner.php
@@ -35,8 +35,8 @@ class BasicRequestSigner implements RequestSigner
 
     public function sign(Request $request, ApiKey $apiKey)
     {
-        date_default_timezone_set(self::TIME_ZONE);
         $date = new \DateTime();
+        $date->setTimezone(new \DateTimeZone(self::TIME_ZONE));
         $timeStamp = $date->format(self::TIMESTAMP_FORMAT);
 
         $requestHeaders = $request->getHeaders();

--- a/src/Http/Authc/SAuthc1RequestSigner.php
+++ b/src/Http/Authc/SAuthc1RequestSigner.php
@@ -45,8 +45,8 @@ class SAuthc1RequestSigner implements RequestSigner
     public function sign(Request $request, ApiKey $apiKey)
     {
 
-        date_default_timezone_set(self::TIME_ZONE);
         $date = new \DateTime();
+        $date->setTimezone(new \DateTimeZone(self::TIME_ZONE));
         $timeStamp = $date->format(self::TIMESTAMP_FORMAT);
         $dateStamp = $date->format(self::DATE_FORMAT);
 


### PR DESCRIPTION
Checklists for Pull requests
----------------------------

About pull request itself:
- [x] My changes contain only a single type of change (one bugfix or feature). 
- [x] I have read and understood CONTRIBUTING guide

Code Coverage:
(not applicable for non-code fixes of course)
- [x] My pull request has tests that cover 100% of the updated code. (phpunit --coverage-html code-coverage)
- [x] My pull request does not remove any tests that are still needed.

Commits:
- [x] My commits are logical, easily readable, with concise comments.
- [x] My code follows PSR standards of coding style

Licensing:
- [x] I am the author of submission or have been authorized by submission copyright holder to issue this pull request.
- [x] Any new files contain the copyright header directly after the opening <?php line

Branching:
- [x] My submission is based on dev branch
- [x] My submission is compatible with latest master branch updates (no conflicts, I did a rebase if it was necessary).
- [x] The name of the branch I want to merge upstream is not 'master'.
- [x] My branch name follows the pattern *feature/some-new-shiny-feature* (for new features).
- [x] My branch name follows the pattern *bugfix/some-bugfix* (for bugfixes).

Continuous integration:
- [x] Once I will submit this pull request, I will wait for Travis-CI report (normally a couple of minutes) and fix any issues I might have introduced.



Pull request description
------------------------
Currently, when signing a request, the SDK will globally change the projects timezone instead of only setting the timezone on the DateTime object used as part of the signing process. 
This remedies that.