### PR TITLE
Update copyrights to 2017

### DIFF
--- a/src/ApiKey.php
+++ b/src/ApiKey.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath;
 class ApiKey
 {
 

--- a/src/Authc/Api/ApiAuthenticationResult.php
+++ b/src/Authc/Api/ApiAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/ApiKeyEncryptionOptions.php
+++ b/src/Authc/Api/ApiKeyEncryptionOptions.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Authc\Api;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Authc\Api;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Authc\Api;
 
 class ApiKeyEncryptionOptions
 {

--- a/src/Authc/Api/ApiKeyEncryptionUtils.php
+++ b/src/Authc/Api/ApiKeyEncryptionUtils.php
@@ -1,12 +1,6 @@
 <?php
-
-namespace Stormpath\Authc\Api;
-
-use phpseclib\Crypt\AES as ModernAES;
-use Crypt_AES as OldAES;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +13,13 @@ use Crypt_AES as OldAES;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Authc\Api;
+
+use phpseclib\Crypt\AES as ModernAES;
+use Crypt_AES as OldAES;
 
 class ApiKeyEncryptionUtils
 {

--- a/src/Authc/Api/ApiRequestAuthenticator.php
+++ b/src/Authc/Api/ApiRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/AuthenticatorResult.php
+++ b/src/Authc/Api/AuthenticatorResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/BasicAuthenticationResult.php
+++ b/src/Authc/Api/BasicAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/BasicRequestAuthenticator.php
+++ b/src/Authc/Api/BasicRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/InternalRequestAuthenticator.php
+++ b/src/Authc/Api/InternalRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/OAuthAuthenticationResult.php
+++ b/src/Authc/Api/OAuthAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Authc/Api/OAuthBearerAuthenticationResult.php
+++ b/src/Authc/Api/OAuthBearerAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/OAuthBearerRequestAuthenticator.php
+++ b/src/Authc/Api/OAuthBearerRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/OAuthClientCredentialsAuthenticationResult.php
+++ b/src/Authc/Api/OAuthClientCredentialsAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/OAuthClientCredentialsRequestAuthenticator.php
+++ b/src/Authc/Api/OAuthClientCredentialsRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/OAuthRequestAuthenticator.php
+++ b/src/Authc/Api/OAuthRequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/Request.php
+++ b/src/Authc/Api/Request.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/Api/RequestAuthenticator.php
+++ b/src/Authc/Api/RequestAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Authc\Api;

--- a/src/Authc/AuthenticationRequest.php
+++ b/src/Authc/AuthenticationRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Authc;
+
 interface AuthenticationRequest {
 
     function getPrincipals();

--- a/src/Authc/BasicAuthenticator.php
+++ b/src/Authc/BasicAuthenticator.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Authc;
 
 use Stormpath\DataStore\InternalDataStore;
 use Stormpath\Stormpath;

--- a/src/Authc/UsernamePasswordRequest.php
+++ b/src/Authc/UsernamePasswordRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Authc;
+
 use Stormpath\Resource\Account;
 use Stormpath\Resource\AccountStore;
 

--- a/src/Cache/ArrayCacheManager.php
+++ b/src/Cache/ArrayCacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 use Cache\Adapter\PHPArray\ArrayCachePool;
 

--- a/src/Cache/Cache.php
+++ b/src/Cache/Cache.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 interface Cache {
 

--- a/src/Cache/CacheManager.php
+++ b/src/Cache/CacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 interface CacheManager {
 

--- a/src/Cache/CachePSR6Adapter.php
+++ b/src/Cache/CachePSR6Adapter.php
@@ -1,12 +1,25 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Cache;
 
 use Cache\Adapter\Common\AbstractCachePool;
 
-/**
-* 
-*/
 class CachePSR6Adapter extends AbstractCachePool
 {
     protected $cache;

--- a/src/Cache/Cacheable.php
+++ b/src/Cache/Cacheable.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 abstract class Cacheable {
 

--- a/src/Cache/MemcachedCacheManager.php
+++ b/src/Cache/MemcachedCacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 use Cache\Adapter\Memcached\MemcachedCachePool;
 use Memcached;

--- a/src/Cache/NullCacheManager.php
+++ b/src/Cache/NullCacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 use Cache\Adapter\Void\VoidCachePool;
 

--- a/src/Cache/PSR6CacheKeyTrait.php
+++ b/src/Cache/PSR6CacheKeyTrait.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Cache;
 

--- a/src/Cache/PSR6CacheManagerInterface.php
+++ b/src/Cache/PSR6CacheManagerInterface.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 interface PSR6CacheManagerInterface {
 

--- a/src/Cache/PSR6InstanceCacheManager.php
+++ b/src/Cache/PSR6InstanceCacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 use Psr\Cache\CacheItemPoolInterface;
 

--- a/src/Cache/RedisCacheManager.php
+++ b/src/Cache/RedisCacheManager.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Cache;
 
 use Cache\Adapter\Redis\RedisCachePool;
 use Redis;

--- a/src/Cache/Tags/CacheTagExtractor.php
+++ b/src/Cache/Tags/CacheTagExtractor.php
@@ -1,10 +1,23 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Cache\Tags;
 
-/**
-* 
-*/
 class CacheTagExtractor
 {
     public static function extractCacheTags($document)

--- a/src/Client.php
+++ b/src/Client.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath;
 
 use Cache\Taggable\TaggablePSR6PoolAdapter;
 use Http\Client\HttpClient;

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath;
 use Stormpath\Cache\ArrayCacheManager;
 use Stormpath\Cache\MemcachedCacheManager;
 use Stormpath\Cache\NullCacheManager;

--- a/src/DataStore/ClassNameResolver.php
+++ b/src/DataStore/ClassNameResolver.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\DataStore;

--- a/src/DataStore/DataStore.php
+++ b/src/DataStore/DataStore.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\DataStore;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\DataStore;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\DataStore;
+
 interface DataStore
 {
     /**

--- a/src/DataStore/DefaultClassNameResolver.php
+++ b/src/DataStore/DefaultClassNameResolver.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\DataStore;

--- a/src/DataStore/DefaultDataStore.php
+++ b/src/DataStore/DefaultDataStore.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\DataStore;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\DataStore;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\DataStore;
 
 use Cache\Taggable\TaggableItemInterface;
 use Cache\Taggable\TaggablePoolInterface;

--- a/src/DataStore/DefaultResourceFactory.php
+++ b/src/DataStore/DefaultResourceFactory.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\DataStore;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\DataStore;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\DataStore;
+
 use Stormpath\Saml\AttributeStatementMappingRuleBuilder;
 use Stormpath\Saml\AttributeStatementMappingRulesBuilder;
 

--- a/src/DataStore/InternalDataStore.php
+++ b/src/DataStore/InternalDataStore.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\DataStore;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\DataStore;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\DataStore;
+
 use Stormpath\Resource\Resource;
 
 /**

--- a/src/DataStore/ResourceFactory.php
+++ b/src/DataStore/ResourceFactory.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\DataStore;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\DataStore;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\DataStore;
+
 interface ResourceFactory
 {
 

--- a/src/Directory/PasswordPolicy.php
+++ b/src/Directory/PasswordPolicy.php
@@ -1,7 +1,6 @@
 <?php
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Directory;

--- a/src/Directory/PasswordStrength.php
+++ b/src/Directory/PasswordStrength.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Directory;

--- a/src/Exceptions/Cache/InvalidCacheManagerException.php
+++ b/src/Exceptions/Cache/InvalidCacheManagerException.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Exceptions\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Exceptions\Cache;
 
 class InvalidCacheManagerException extends \LogicException {
 

--- a/src/Exceptions/Cache/InvalidLegacyCacheManagerException.php
+++ b/src/Exceptions/Cache/InvalidLegacyCacheManagerException.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Exceptions\Cache;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Exceptions\Cache;
 
 class InvalidLegacyCacheManagerException extends \LogicException {
 

--- a/src/Exceptions/IdSite/InvalidCallbackUriException.php
+++ b/src/Exceptions/IdSite/InvalidCallbackUriException.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Exceptions\IdSite;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
+namespace Stormpath\Exceptions\IdSite;
 
 class InvalidCallbackUriException extends \Exception {
 

--- a/src/Exceptions/IdSite/JWTUsedAlreadyException.php
+++ b/src/Exceptions/IdSite/JWTUsedAlreadyException.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Exceptions\IdSite;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
+namespace Stormpath\Exceptions\IdSite;
 
 class JWTUsedAlreadyException extends \Exception {
 

--- a/src/Exceptions/RequestAuthenticatorException.php
+++ b/src/Exceptions/RequestAuthenticatorException.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Exceptions;

--- a/src/Http/Authc/BasicRequestSigner.php
+++ b/src/Http/Authc/BasicRequestSigner.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Http\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +13,10 @@ namespace Stormpath\Http\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
+namespace Stormpath\Http\Authc;
 /**
  * @deprecated Pass the $authenticationScheme option to Client/ClientBuilder instead
  */

--- a/src/Http/Authc/RequestSigner.php
+++ b/src/Http/Authc/RequestSigner.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Http\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Http\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Http\Authc;
 
 /**
  * @deprecated Pass the $authenticationScheme option to Client/ClientBuilder instead

--- a/src/Http/Authc/SAuthc1Authentication.php
+++ b/src/Http/Authc/SAuthc1Authentication.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Http\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Http\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Http\Authc;
 
 use Http\Message\Authentication;
 use Psr\Http\Message\RequestInterface;

--- a/src/Http/Authc/SAuthc1RequestSigner.php
+++ b/src/Http/Authc/SAuthc1RequestSigner.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Http\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Http\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Http\Authc;
 
 /**
  * @deprecated Pass the $authenticationScheme option to Client/ClientBuilder instead

--- a/src/Http/Authc/StormpathBasicAuthentication.php
+++ b/src/Http/Authc/StormpathBasicAuthentication.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Http\Authc;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Http\Authc;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Http\Authc;
 
 use Http\Message\Authentication;
 use Psr\Http\Message\RequestInterface;

--- a/src/Mail/EmailTemplate.php
+++ b/src/Mail/EmailTemplate.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Mail;
 

--- a/src/Mail/ModeledEmailTemplate.php
+++ b/src/Mail/ModeledEmailTemplate.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Mail;

--- a/src/Mail/ModeledEmailTemplateList.php
+++ b/src/Mail/ModeledEmailTemplateList.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Mail;

--- a/src/Mail/UnmodeledEmailTemplate.php
+++ b/src/Mail/UnmodeledEmailTemplate.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Mail;

--- a/src/Mail/UnmodeledEmailTemplateList.php
+++ b/src/Mail/UnmodeledEmailTemplateList.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Mail;

--- a/src/Mfa/Challenge.php
+++ b/src/Mfa/Challenge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/ChallengeList.php
+++ b/src/Mfa/ChallengeList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/Factor.php
+++ b/src/Mfa/Factor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/FactorList.php
+++ b/src/Mfa/FactorList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/GoogleAuthenticatorChallenge.php
+++ b/src/Mfa/GoogleAuthenticatorChallenge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/GoogleAuthenticatorFactor.php
+++ b/src/Mfa/GoogleAuthenticatorFactor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/Phone.php
+++ b/src/Mfa/Phone.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  *
  */
 

--- a/src/Mfa/PhoneList.php
+++ b/src/Mfa/PhoneList.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  *
  */
 

--- a/src/Mfa/SmsChallenge.php
+++ b/src/Mfa/SmsChallenge.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Mfa/SmsFactor.php
+++ b/src/Mfa/SmsFactor.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Oauth/ExchangeIdSiteTokenAttempt.php
+++ b/src/Oauth/ExchangeIdSiteTokenAttempt.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/ExchangeIdSiteTokenAuthenticator.php
+++ b/src/Oauth/ExchangeIdSiteTokenAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/ExchangeIdSiteTokenRequest.php
+++ b/src/Oauth/ExchangeIdSiteTokenRequest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/OauthGrantAuthenticationResult.php
+++ b/src/Oauth/OauthGrantAuthenticationResult.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/OauthGrantAuthenticationResultBuilder.php
+++ b/src/Oauth/OauthGrantAuthenticationResultBuilder.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/PasswordGrantAuthenticationAttempt.php
+++ b/src/Oauth/PasswordGrantAuthenticationAttempt.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/PasswordGrantAuthenticator.php
+++ b/src/Oauth/PasswordGrantAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/PasswordGrantRequest.php
+++ b/src/Oauth/PasswordGrantRequest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/RefreshGrantAuthenticationAttempt.php
+++ b/src/Oauth/RefreshGrantAuthenticationAttempt.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/RefreshGrantAuthenticator.php
+++ b/src/Oauth/RefreshGrantAuthenticator.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/RefreshGrantRequest.php
+++ b/src/Oauth/RefreshGrantRequest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Oauth/VerifyAccessToken.php
+++ b/src/Oauth/VerifyAccessToken.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Oauth;

--- a/src/Provider/FacebookProviderAccountRequest.php
+++ b/src/Provider/FacebookProviderAccountRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Provider;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Provider;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Provider;
 
 use Stormpath\DataStore\DataStore;
 use Stormpath\Resource\FacebookProviderData;

--- a/src/Provider/GithubProviderAccountRequest.php
+++ b/src/Provider/GithubProviderAccountRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Provider;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Provider;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Provider;
 
 use Stormpath\DataStore\DataStore;
 use Stormpath\Resource\GithubProviderData;

--- a/src/Provider/GoogleProviderAccountRequest.php
+++ b/src/Provider/GoogleProviderAccountRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Provider;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Provider;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Provider;
 
 use Stormpath\DataStore\DataStore;
 use Stormpath\Resource\GoogleProviderData;

--- a/src/Provider/LinkedInProviderAccountRequest.php
+++ b/src/Provider/LinkedInProviderAccountRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Provider;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Provider;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Provider;
 
 use Stormpath\DataStore\DataStore;
 use Stormpath\Resource\GithubProviderData;

--- a/src/Provider/ProviderAccountRequest.php
+++ b/src/Provider/ProviderAccountRequest.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Provider;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Provider;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Provider;
 
 interface ProviderAccountRequest
 {

--- a/src/Provider/ProviderDataClassNameResolver.php
+++ b/src/Provider/ProviderDataClassNameResolver.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Provider;

--- a/src/Resource/AbstractCollectionResource.php
+++ b/src/Resource/AbstractCollectionResource.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/AccessToken.php
+++ b/src/Resource/AccessToken.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Resource/AccessTokenList.php
+++ b/src/Resource/AccessTokenList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/Account.php
+++ b/src/Resource/Account.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/AccountCreationPolicy.php
+++ b/src/Resource/AccountCreationPolicy.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/AccountList.php
+++ b/src/Resource/AccountList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/AccountStore.php
+++ b/src/Resource/AccountStore.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/AccountStoreMapping.php
+++ b/src/Resource/AccountStoreMapping.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/AccountStoreMappingList.php
+++ b/src/Resource/AccountStoreMappingList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/ApiKey.php
+++ b/src/Resource/ApiKey.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/ApiKeyList.php
+++ b/src/Resource/ApiKeyList.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Resource/Application.php
+++ b/src/Resource/Application.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Firebase\JWT\JWT;
 use Stormpath\Authc\Api\ApiKeyEncryptionOptions;

--- a/src/Resource/ApplicationList.php
+++ b/src/Resource/ApplicationList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/AssertionConsumerServicePostEndpoint.php
+++ b/src/Resource/AssertionConsumerServicePostEndpoint.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Resource;
 

--- a/src/Resource/AuthenticationResult.php
+++ b/src/Resource/AuthenticationResult.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/BasicLoginAttempt.php
+++ b/src/Resource/BasicLoginAttempt.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\DataStore\InternalDataStore;
 

--- a/src/Resource/CustomData.php
+++ b/src/Resource/CustomData.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Resource;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 
 class CustomData extends InstanceResource implements Saveable {

--- a/src/Resource/Deletable.php
+++ b/src/Resource/Deletable.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 interface Deletable {
 

--- a/src/Resource/Directory.php
+++ b/src/Resource/Directory.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\Stormpath;

--- a/src/Resource/DirectoryList.php
+++ b/src/Resource/DirectoryList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/EmailVerificationToken.php
+++ b/src/Resource/EmailVerificationToken.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,11 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
+
 // @codeCoverageIgnoreStart
 class EmailVerificationToken extends InstanceResource
 {

--- a/src/Resource/Error.php
+++ b/src/Resource/Error.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class Error extends Resource
 {

--- a/src/Resource/Expansion.php
+++ b/src/Resource/Expansion.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/FacebookProvider.php
+++ b/src/Resource/FacebookProvider.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\DataStore\InternalDataStore;

--- a/src/Resource/FacebookProviderData.php
+++ b/src/Resource/FacebookProviderData.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class FacebookProviderData extends ProviderData
 {

--- a/src/Resource/GithubProvider.php
+++ b/src/Resource/GithubProvider.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\DataStore\InternalDataStore;

--- a/src/Resource/GithubProviderData.php
+++ b/src/Resource/GithubProviderData.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class GithubProviderData extends ProviderData
 {

--- a/src/Resource/GoogleProvider.php
+++ b/src/Resource/GoogleProvider.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\DataStore\InternalDataStore;

--- a/src/Resource/GoogleProviderData.php
+++ b/src/Resource/GoogleProviderData.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class GoogleProviderData extends ProviderData
 {

--- a/src/Resource/GrantAuthenticationToken.php
+++ b/src/Resource/GrantAuthenticationToken.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Resource/Group.php
+++ b/src/Resource/Group.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\Stormpath;

--- a/src/Resource/GroupList.php
+++ b/src/Resource/GroupList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/GroupMembership.php
+++ b/src/Resource/GroupMembership.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\DataStore\InternalDataStore;

--- a/src/Resource/GroupMembershipList.php
+++ b/src/Resource/GroupMembershipList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/InstanceResource.php
+++ b/src/Resource/InstanceResource.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class InstanceResource extends Resource implements Saveable
 {

--- a/src/Resource/LinkedInProvider.php
+++ b/src/Resource/LinkedInProvider.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\DataStore\InternalDataStore;

--- a/src/Resource/LinkedInProviderData.php
+++ b/src/Resource/LinkedInProviderData.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class LinkedInProviderData extends ProviderData
 {

--- a/src/Resource/OauthPolicy.php
+++ b/src/Resource/OauthPolicy.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\Stormpath;

--- a/src/Resource/Order.php
+++ b/src/Resource/Order.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 use Stormpath\Util\Magic;

--- a/src/Resource/Organization.php
+++ b/src/Resource/Organization.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/OrganizationList.php
+++ b/src/Resource/OrganizationList.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/Page.php
+++ b/src/Resource/Page.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Util\Magic;
 

--- a/src/Resource/PaginatedIterator.php
+++ b/src/Resource/PaginatedIterator.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/Resource/PasswordResetToken.php
+++ b/src/Resource/PasswordResetToken.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/Provider.php
+++ b/src/Resource/Provider.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class Provider extends Resource
 {

--- a/src/Resource/ProviderAccountAccess.php
+++ b/src/Resource/ProviderAccountAccess.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
+namespace Stormpath\Resource;
 
 class ProviderAccountAccess extends Resource
 {

--- a/src/Resource/ProviderAccountResult.php
+++ b/src/Resource/ProviderAccountResult.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/ProviderData.php
+++ b/src/Resource/ProviderData.php
@@ -1,10 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-use Stormpath\Stormpath;
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +13,12 @@ use Stormpath\Stormpath;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
+
+use Stormpath\Stormpath;
 
 class ProviderData extends Resource
 {

--- a/src/Resource/RefreshToken.php
+++ b/src/Resource/RefreshToken.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/src/Resource/RefreshTokenList.php
+++ b/src/Resource/RefreshTokenList.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 

--- a/src/Resource/Resource.php
+++ b/src/Resource/Resource.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\DataStore\InternalDataStore;
 use Stormpath\Util\Magic;

--- a/src/Resource/ResourceError.php
+++ b/src/Resource/ResourceError.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 class ResourceError extends \RuntimeException
 {

--- a/src/Resource/SamlProvider.php
+++ b/src/Resource/SamlProvider.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/SamlProviderData.php
+++ b/src/Resource/SamlProviderData.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Resource/Saveable.php
+++ b/src/Resource/Saveable.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 interface Saveable
 {

--- a/src/Resource/Search.php
+++ b/src/Resource/Search.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Stormpath;
 use Stormpath\Util\Magic;

--- a/src/Resource/Tenant.php
+++ b/src/Resource/Tenant.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\Stormpath;

--- a/src/Resource/VerificationEmail.php
+++ b/src/Resource/VerificationEmail.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Resource;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Resource;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Resource;
 
 use Stormpath\Client;
 use Stormpath\Stormpath;

--- a/src/Resource/X509SigningCert.php
+++ b/src/Resource/X509SigningCert.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Resource;

--- a/src/Saml/AttributeStatementMappingRule.php
+++ b/src/Saml/AttributeStatementMappingRule.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Saml;

--- a/src/Saml/AttributeStatementMappingRuleBuilder.php
+++ b/src/Saml/AttributeStatementMappingRuleBuilder.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Saml;

--- a/src/Saml/AttributeStatementMappingRules.php
+++ b/src/Saml/AttributeStatementMappingRules.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Saml;

--- a/src/Saml/AttributeStatementMappingRulesBuilder.php
+++ b/src/Saml/AttributeStatementMappingRulesBuilder.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Saml;
 

--- a/src/Stormpath.php
+++ b/src/Stormpath.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath;
 
 class Stormpath
 {

--- a/src/Util/Magic.php
+++ b/src/Util/Magic.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Util;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Util;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Util;
 
 class Magic {
 

--- a/src/Util/NonceStore.php
+++ b/src/Util/NonceStore.php
@@ -1,4 +1,22 @@
-<?php namespace Stormpath\Util;
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Stormpath\Util;
 
 
 use Stormpath\DataStore\DataStore;

--- a/src/Util/RequestUtils.php
+++ b/src/Util/RequestUtils.php
@@ -1,11 +1,6 @@
 <?php
-
-namespace Stormpath\Util;
-
-use Psr\Http\Message\UriInterface;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +13,12 @@ use Psr\Http\Message\UriInterface;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Util;
+
+use Psr\Http\Message\UriInterface;
 
 class RequestUtils
 {

--- a/src/Util/UUID.php
+++ b/src/Util/UUID.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Util;
 

--- a/src/Util/UserAgentBuilder.php
+++ b/src/Util/UserAgentBuilder.php
@@ -1,5 +1,20 @@
 <?php
-
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Util;
 

--- a/src/Util/Version.php
+++ b/src/Util/Version.php
@@ -1,9 +1,6 @@
 <?php
-
-namespace Stormpath\Util;
-
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +13,10 @@ namespace Stormpath\Util;
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
+
+namespace Stormpath\Util;
 
 class Version
 {

--- a/tests/Authc/Api/ApiRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/ApiRequestAuthenticatorTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\ApiRequestAuthenticator;

--- a/tests/Authc/Api/BasicRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/BasicRequestAuthenticatorTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\BasicRequestAuthenticator;

--- a/tests/Authc/Api/OAuthBearerRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthBearerRequestAuthenticatorTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\OAuthBearerAuthenticationResult;

--- a/tests/Authc/Api/OAuthClientCredentialsAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthClientCredentialsAuthenticatorTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\OAuthClientCredentialsRequestAuthenticator;

--- a/tests/Authc/Api/OAuthPasswordRequestAuthenticatorRequest.php
+++ b/tests/Authc/Api/OAuthPasswordRequestAuthenticatorRequest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\OAuthPasswordRequestAuthenticator;

--- a/tests/Authc/Api/OAuthRequestAuthenticatorTest.php
+++ b/tests/Authc/Api/OAuthRequestAuthenticatorTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Authc\Api;
 
 use Stormpath\Authc\Api\OAuthPasswordRequestAuthenticator;

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 use Symfony\Component\Debug\Debug;

--- a/tests/Cache/ArrayCacheManagerTest.php
+++ b/tests/Cache/ArrayCacheManagerTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Cache;
 

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -1,4 +1,22 @@
-<?php namespace Stormpath\Tests\Cache;
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Stormpath\Tests\Cache;
 
 use Stormpath\Cache\Cacheable;
 use Stormpath\Cache\PSR6CacheKeyTrait;

--- a/tests/Cache/MemcachedCacheManagerTest.php
+++ b/tests/Cache/MemcachedCacheManagerTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Cache;
 

--- a/tests/Cache/NullCacheManagerTest.php
+++ b/tests/Cache/NullCacheManagerTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Cache;
 

--- a/tests/Cache/RedisCacheManagerTest.php
+++ b/tests/Cache/RedisCacheManagerTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Cache;
 

--- a/tests/Cache/Tags/CacheTagExtractorTest.php
+++ b/tests/Cache/Tags/CacheTagExtractorTest.php
@@ -1,4 +1,22 @@
-<?php namespace Stormpath\Tests\Cache;
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+namespace Stormpath\Tests\Cache;
 
 use Stormpath\Cache\Tags\CacheTagExtractor;
 

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Tests;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
+namespace Stormpath\Tests;
 
 use Stormpath\Stormpath;
 use Stormpath\Util\UserAgentBuilder;

--- a/tests/Directory/PasswordPolicyTest.php
+++ b/tests/Directory/PasswordPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Directory;

--- a/tests/Directory/PasswordStrengthTest.php
+++ b/tests/Directory/PasswordStrengthTest.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Directory;

--- a/tests/Http/Authc/RequestSignerTest.php
+++ b/tests/Http/Authc/RequestSignerTest.php
@@ -1,4 +1,21 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 namespace Stormpath\Tests\Http\Authc;
 
 use Stormpath\Stormpath;

--- a/tests/Mail/ModeledEmailTemplateListTest.php
+++ b/tests/Mail/ModeledEmailTemplateListTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Tests\Mail;
 

--- a/tests/Mail/ModeledEmailTemplateTest.php
+++ b/tests/Mail/ModeledEmailTemplateTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Tests\Mail;
 

--- a/tests/Mail/UnmodeledEmailTemplateListTest.php
+++ b/tests/Mail/UnmodeledEmailTemplateListTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Tests\Mail;
 

--- a/tests/Mail/UnmodeledEmailTemplateTest.php
+++ b/tests/Mail/UnmodeledEmailTemplateTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Tests\Mail;
 

--- a/tests/Mfa/ChallengeListTest.php
+++ b/tests/Mfa/ChallengeListTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Challenge;

--- a/tests/Mfa/ChallengeTest.php
+++ b/tests/Mfa/ChallengeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/FactorListTest.php
+++ b/tests/Mfa/FactorListTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/FactorTest.php
+++ b/tests/Mfa/FactorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/GoogleAuthenticatorFactorTest.php
+++ b/tests/Mfa/GoogleAuthenticatorFactorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/PhoneListTest.php
+++ b/tests/Mfa/PhoneListTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Mfa;

--- a/tests/Mfa/PhoneTest.php
+++ b/tests/Mfa/PhoneTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/Physical/SmsTest.php
+++ b/tests/Mfa/Physical/SmsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/SmsChallengeTest.php
+++ b/tests/Mfa/SmsChallengeTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Mfa/SmsFactorTest.php
+++ b/tests/Mfa/SmsFactorTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Stormpath, Inc.
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/Oauth/PasswordRefreshGrantTest.php
+++ b/tests/Oauth/PasswordRefreshGrantTest.php
@@ -1,5 +1,20 @@
 <?php
-
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 use Stormpath\Client;
 

--- a/tests/Resource/AccountCreationPolicyTest.php
+++ b/tests/Resource/AccountCreationPolicyTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/AccountStoreMappingTest.php
+++ b/tests/Resource/AccountStoreMappingTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/AccountTest.php
+++ b/tests/Resource/AccountTest.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 namespace Stormpath\Tests\Resource;
 

--- a/tests/Resource/ApplicationTest.php
+++ b/tests/Resource/ApplicationTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/DirectoryTest.php
+++ b/tests/Resource/DirectoryTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/GroupMembershipTest.php
+++ b/tests/Resource/GroupMembershipTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/GroupTest.php
+++ b/tests/Resource/GroupTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/OrganizationTest.php
+++ b/tests/Resource/OrganizationTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 

--- a/tests/Resource/ProviderTest.php
+++ b/tests/Resource/ProviderTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Resource/SamlProviderMetadataTest.php
+++ b/tests/Resource/SamlProviderMetadataTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Resource;
 

--- a/tests/Resource/SamlProviderTest.php
+++ b/tests/Resource/SamlProviderTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Resource;
 

--- a/tests/Resource/TenantTest.php
+++ b/tests/Resource/TenantTest.php
@@ -1,6 +1,6 @@
 <?php
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests\Resource;

--- a/tests/Saml/AttributeStatementMappingRuleTest.php
+++ b/tests/Saml/AttributeStatementMappingRuleTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Saml;
 

--- a/tests/Saml/AttributeStatementMappingRulesBuilderTest.php
+++ b/tests/Saml/AttributeStatementMappingRulesBuilderTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Saml;
 

--- a/tests/Saml/AttributeStatementmappingRuleBuilderTest.php
+++ b/tests/Saml/AttributeStatementmappingRuleBuilderTest.php
@@ -1,4 +1,20 @@
 <?php
+/**
+ * Copyright 2017 Stormpath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
 
 namespace Stormpath\Tests\Saml;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 
-/*
- * Copyright 2016 Stormpath, Inc.
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 namespace Stormpath\Tests;

--- a/tests/UserAgentTest.php
+++ b/tests/UserAgentTest.php
@@ -1,6 +1,6 @@
-<?php namespace Stormpath\Tests;
-/*
- * Copyright 2016 Stormpath, Inc.
+<?php
+/**
+ * Copyright 2017 Stormpath, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,9 +13,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-
+namespace Stormpath\Tests;
 
 use Stormpath\Util\UserAgentBuilder;
 use Stormpath\Util\Version;


### PR DESCRIPTION
Updates all copyrights to 2017 and makes sure they are compliant with the Copyright profile for PHP Storm.  

This PR resolves #191 